### PR TITLE
新規カテゴリー追加の際にプルダウンで登録済みのカテゴリーを選択可能に。

### DIFF
--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -215,8 +215,9 @@ export default {
           },
         };
         commit('updateArticle', payload);
-        commit('toggleLoading');
+        // console.log(payload);
         commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+        commit('toggleLoading');
       }).catch(() => {
         commit('toggleLoading');
       });
@@ -272,5 +273,30 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    // resisterArticle({ commit }) {
+    //   commit('toggleLoading');
+    //   const data = new URLSearchParams();
+    //   data.append('title', rootGetters['articles/targetArticle'].title);
+    //   data.append('content', rootGetters['articles/targetArticle'].content);
+    //   data.append('category_id', rootGetters['articles/targetArticle'].category.id);
+    //   console.log(data);
+    //   axious(rootGetters['auth/token'])({
+    //     method: 'POST',
+    //     url:'/article',
+    //     data,
+    //   }).then(response)(() => {
+    //     // const payload = {
+    //     //   id: response.data.article.id,
+    //     //   title: response.data.article.title,
+    //     //   content: response.data.article.content,
+    //     // const payload = {articles = []};
+    //     // payload.articles.push(response.data.article);
+    //     // commit('', payload);
+    //     commit('displayDoneMessage', { message: 'ドキュメントを更新しました' });
+    //     commit('toggleLoading');
+    //   }).catch(error)(() => {
+    //     commit('toggleLoading');
+    //   });
+    // },
   },
 };

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -63,7 +63,10 @@ export default {
         highlight: (code, lang) => hljs.highlightAuto(code, [lang]).value,
         breaks: false,
         smartLists: true,
+        sanitize: true,
       });
+      // const markDown = this.markdownContent;
+      // console.log(markDown);
       return marked(this.markdownContent);
     },
   },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,0 +1,198 @@
+<template lang="html">
+  <div class="article-create">
+    <div v-if="doneMessage" class="article-edit__notice--update">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <div v-if="errorMessage" class="article-edit__notice--update">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
+    <div class="article-create__columns">
+      <section class="article-create-editor">
+        <app-heading :level="1">記事の新規作成</app-heading>
+        <app-heading
+          class="article-create-editor-title"
+          :level="2"
+        >
+          カテゴリーの選択
+        </app-heading>
+        <app-select
+          v-validate="'required'"
+          name="category"
+          data-vv-as="カテゴリー"
+          :value="currentCategoryName"
+          :error-messages="errors.collect('category')"
+          @updateValue="$emit('selectedArticleCategory', $event)"
+        >
+          <option
+            value=""
+            selected
+            disabled
+          >
+            ---
+          </option>
+          <option
+            v-for="(category) in categoryList"
+            :key="category.id"
+            :value="category.name"
+            :selected="currentCategoryName === category.name ? true : false "
+          >
+            {{ category.name }}
+          </option>
+        </app-select>
+        <app-heading
+          class="article-create-editor-title"
+          :level="2"
+        >
+          タイトル・本文
+        </app-heading>
+        <div class="article-create-form">
+          <app-input
+            v-validate="'required'"
+            name="title"
+            type="text"
+            placeholder="記事のタイトルを入力してください。"
+            white-bg
+            data-vv-as="記事のタイトル"
+            :error-messages="errors.collect('title')"
+            :value="articleTitle"
+            @updateValue="$emit('editedTitle', $event)"
+          />
+        </div>
+
+        <div class="article-create-form">
+          <app-textarea
+            v-validate="'required'"
+            name="content"
+            placeholder="記事の本文をマークダウン記法で入力してください。"
+            white-bg
+            data-vv-as="記事の本文"
+            :error-messages="errors.collect('content')"
+            :value="articleContent"
+            @updateValue="$emit('editedContent', $event)"
+          />
+        </div>
+        <app-button
+          class="article-create-submit"
+          button-type="submit"
+          round
+          :disabled="!disabled"
+          @click="handleSubmit"
+        >
+          {{ buttonText }}
+        </app-button>
+      </section>
+      <article class="article-create-preview">
+        <app-markdown-preview
+          :markdown-content="markdownContent"
+        />
+      </article>
+    </div>
+  </div>
+</template>
+<script>
+import {
+  Heading, Input, Textarea, MarkdownPreview, Button, Select, Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appTextarea: Textarea,
+    appMarkdownPreview: MarkdownPreview,
+    appInput: Input,
+    appButton: Button,
+    appSelect: Select,
+    appText: Text,
+  },
+  props: {
+    articleId: {
+      type: Number,
+      default: 0,
+    },
+    articleTitle: {
+      type: String,
+      default: '',
+    },
+    articleContent: {
+      type: String,
+      default: '',
+    },
+    markdownContent: {
+      type: String,
+      default: '',
+    },
+    currentCategoryName: {
+      type: String,
+      default: '',
+    },
+    categoryList: {
+      type: Array,
+      default: () => [],
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '作成権限がありません';
+      return this.loading ? '作成中...' : '作成';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+  },
+};
+</script>
+<style lang="postcss" scoped>
+.article-create {
+  &__columns {
+    display: flex;
+    height: 100%;
+  }
+  &-editor {
+    padding-right: 2%;
+    width: 50%;
+    border-right: 1px solid #ccc;
+    &-title {
+      margin-top: 16px;
+    }
+  }
+  &-preview {
+    margin-left: 2%;
+    width: 48%;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+  &-form {
+    margin-top: 20px;
+  }
+  &-submit {
+    margin-top: 16px;
+  }
+  &__notice--update {
+    margin-bottom: 16px;
+  }
+}
+</style>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,5 +1,100 @@
 <template lang="html">
   <div>
-    ドキュメントの新規作成画面です
+    <app-article-post
+      :article-id="articleId"
+      :article-title="articleTitle"
+      :article-content="articleContent"
+      :markdown-content="markdownContent"
+      :current-category-name="currentCategoryName"
+      :category-list="categoryList"
+      :loading="loading"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      :access="access"
+      @selectedArticleCategory="selectedArticleCategory"
+      @handleSubmit="handleSubmit"
+      @editedTitle="editedTitle"
+      @editedContent="editedContent"
+    />
   </div>
 </template>
+<script>
+import { ArticlePost } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticlePost: ArticlePost,
+  },
+  data() {
+    return {
+      title: '',
+      content: '',
+    };
+  },
+  computed: {
+    articleId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    articleTitle() {
+      const { title } = this.$store.state.articles.targetArticle;
+      return title;
+    },
+    articleContent() {
+      const { content } = this.$store.state.articles.targetArticle;
+      return content;
+    },
+    markdownContent() {
+      return `# ${this.articleTitle}\n${this.articleContent}`;
+    },
+    currentCategoryName() {
+      const { name } = this.$store.state.articles.targetArticle.category;
+      return name;
+    },
+    categoryList() {
+      const { categoryList } = this.$store.state.categories;
+      return categoryList;
+    },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories'); // 表示がされる際に登録されているカテゴリーを取得してきている。ドロップダウンメニューに表示するため。
+  },
+  methods: {
+    selectedArticleCategory($event) {
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    },
+    editedTitle($event) {
+      this.$store.dispatch('articles/editedTitle', $event.target.value);
+    },
+    editedContent($event) {
+      this.$store.dispatch('articles/editedContent', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('articles/postArticle').then(() => { // postArticleが終了したら.thne以下を行う。
+        this.$router.push({ // 使用しているRouterLinkにpushしている。表示が変わる。
+          path: '/articles',
+          query: { redirect: '/article/post' },
+          // redirect: '/article/post',
+        });
+        // console.log(this.$router);
+      });
+    },
+  },
+};
+
+</script>


### PR DESCRIPTION
マークダウン形式での登録フォーム（2カラム）
紐づく記事にAPIを使用しての登録（通信成功、通信失敗などの表示）
マークダウン形式の際にサニタイズの適応

マージお願いします。