### PR TITLE
カテゴリ更新の際の空欄バリデーション 設定、アクション・ミューテーションの重複削除

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -103,9 +103,9 @@ export default {
           commit('doneUpdateCategory');
           commit('toggleLoading');
           resolve();
-        }).catch(() => {
-          commit('errorUpdateCategory');
+        }).catch((err) => {
           commit('toggleLoading');
+          commit('failFetchCategory', { message: err.message });
           reject();
         });
       });
@@ -127,9 +127,6 @@ export default {
     },
     updateCategory(state, payload) {
       state.updateCategoryName = payload.name;
-    },
-    errorUpdateCategory(state) {
-      state.errorMessage = 'カテゴリーの更新に失敗しました';
     },
     doneUpdateCategory(state) {
       state.doneMessage = 'カテゴリーの更新が完了しました';

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,11 +12,13 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
       :value="currentCategoryName"
       @updateValue="$emit('editedCategory', $event)"
     />


### PR DESCRIPTION
課題２の修正を完了しました。
ご確認お願いします！


>以下2箇所確認して修正してください！
>・レビュー条件のinputタグにはテキスト入力必須のバリデーションが適用されていることが適用されてません
>・actionのupdateCategory内で使われてるエラー表示の処理ですが、既にイベントが用意されているので新規でイベントは作らず既存を使いまわしましょう。
