### PR TITLE
カテゴリー新規作成の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -84,8 +84,31 @@ export default {
         commit('toggleLoading');
       });
     },
+    postCategory({ commit, rootGetters }, postCategory) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', postCategory);
+      axios(rootGetters['auth/token'])({
+        method: 'POST',
+        url: '/category',
+        data,
+      }).then((response) => {
+        const payload = response.data.category;
+        commit('donePostCategory', payload);
+        commit('toggleLoading');
+      }).catch(() => {
+        commit('toggleLoading');
+      });
+    },
   },
   mutations: {
+    donePostCategory(state, payload) {
+      state.categoryList.push(payload);
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
+    applyRequest(state) {
+      state.loading = true;
+    },
     clearMessage(state) {
       state.errorMessage = '';
       state.doneMessage = '';

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,29 +85,27 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }, postCategory) {
-      commit('toggleLoading');
-      const data = new URLSearchParams();
-      data.append('name', postCategory);
-      axios(rootGetters['auth/token'])({
-        method: 'POST',
-        url: '/category',
-        data,
-      }).then((response) => {
-        const payload = response.data.category;
-        commit('donePostCategory', payload);
+      return new Promise((resolve) => {
         commit('toggleLoading');
-      }).catch(() => {
-        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', postCategory);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('donePostCategory');
+          commit('toggleLoading');
+          resolve();
+        }).catch(() => {
+          commit('toggleLoading');
+        });
       });
     },
   },
   mutations: {
-    donePostCategory(state, payload) {
-      state.categoryList.push(payload);
+    donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
-    },
-    applyRequest(state) {
-      state.loading = true;
     },
     clearMessage(state) {
       state.errorMessage = '';

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -16,6 +16,7 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
+       @click="addCategory"
     >
       {{ buttonText }}
     </app-button>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -73,8 +73,12 @@ export default {
       this[$event.target.name] = $event.target.value;
     },
     handleSubmit() {
+      if (this.loading) return;
       const postCategory = this.category;
-      this.$store.dispatch('categories/postCategory', postCategory);
+      this.$store.dispatch('categories/postCategory', postCategory)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </section>
     <section class="category-management-list">
@@ -70,6 +71,10 @@ export default {
   methods: {
     updateValue($event) {
       this[$event.target.name] = $event.target.value;
+    },
+    handleSubmit() {
+      const postCategory = this.category;
+      this.$store.dispatch('categories/postCategory', postCategory);
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');


### PR DESCRIPTION
- 「作成」ボタンを押すとインプットタグ内に入力されている値を新しいカテゴリとして追加。
- 「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性にする。
-　カテゴリーの作成に成功したときは、「カテゴリーの追加が完了しました」というメッセージが表示。
-　カテゴリーの作成に成功したあと、カテゴリー一覧の表示を更新。