### PR TITLE
カテゴリー更新機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,6 +19,17 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    getCategory({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then((response) => {
+        const payload = response.data.category.name;
+        commit('doneUpdateCategory', payload);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -78,6 +89,9 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
       state.doneMessage = 'カテゴリーの削除が完了しました。';
+    },
+    doneUpdateCategory(state, payload) {
+      state.updateCategoryName = payload;
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -24,7 +24,7 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then((response) => {
-        const payload = response.data.category.name;
+        const payload = response.data.category;
         commit('doneUpdateCategory', payload);
       }).catch((err) => {
         commit('failFetchCategory', { message: err.message });
@@ -63,6 +63,27 @@ export default {
         });
       });
     },
+    updateCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', this.state.categories.updateCategoryName);
+      data.append('id', this.state.categories.updateCategoryId);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${this.state.categories.updateCategoryId}`,
+        data,
+      }).then((response) => {
+        const payload = response.data.category;
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+        commit('toggleLoading');
+      });
+    },
+    editName({ commit }, name) {
+      commit('editName', { name });
+    },
   },
   mutations: {
     donePostCategory(state) {
@@ -91,7 +112,16 @@ export default {
       state.doneMessage = 'カテゴリーの削除が完了しました。';
     },
     doneUpdateCategory(state, payload) {
-      state.updateCategoryName = payload;
+      state.updateCategoryName = payload.name;
+      state.updateCategoryId = payload.id;
+    },
+    editName(state, payload) {
+      state.updateCategoryName = payload.name;
+    },
+    updateCategory(state, payload) {
+      state.updateCategoryName = payload.name;
+      state.updateCategoryId = payload.id;
+      state.doneMessage = 'カテゴリーの変更が完了しました。';
     },
   },
 };

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,28 +12,31 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
-       :value="categoryName"
+      data-vv-as="カテゴリー名"
+      :value="categoryName"
+      @updateValue="$emit('editName', $event)"
+      :error-messages="errors.collect('updateCategory')"
     />
     <app-button
       class="category-management-edit__submit"
       button-type="submit"
       round
       :disabled="disabled || !access.edit"
+      @click="handleSubmit"
     >
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -63,6 +66,14 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {
@@ -75,7 +86,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('updateCategory');
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -17,6 +17,7 @@
       type="text"
       placeholder="カテゴリー名を入力してください"
       data-vv-as=""
+       :value="categoryName"
     />
     <app-button
       class="category-management-edit__submit"
@@ -53,6 +54,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+    categoryName: {
+      type: String,
+      default: '',
     },
     access: {
       type: Object,

--- a/src/js/pages/Articles/Edit.vue
+++ b/src/js/pages/Articles/Edit.vue
@@ -65,7 +65,7 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('categories/getCategory');
     this.$store.dispatch('articles/getArticleDetail', parseInt(this.articleId, 10));
   },
   methods: {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -5,7 +5,11 @@
       :access="access"
       :category-id="categoryId"
       :category-name="categoryName"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
       @clearMessage="clearMessage"
+      @updateCategory="updateCategory"
+      @editName="editName"
     />
   </div>
 </template>
@@ -33,6 +37,12 @@ export default {
       const name = this.$store.state.categories.updateCategoryName;
       return name;
     },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
   },
   created() {
     this.$store.dispatch('categories/getCategory', parseInt(this.categoryId, 10));
@@ -40,6 +50,13 @@ export default {
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    updateCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+    editName($event) {
+      this.$store.dispatch('categories/editName', $event.target.value);
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -3,6 +3,8 @@
     <app-category-edit
       :disabled="loading ? true : false"
       :access="access"
+      :category-id="categoryId"
+      :category-name="categoryName"
       @clearMessage="clearMessage"
     />
   </div>
@@ -22,6 +24,18 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    categoryId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    categoryName() {
+      const name = this.$store.state.categories.updateCategoryName;
+      return name;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategory', parseInt(this.categoryId, 10));
   },
   methods: {
     clearMessage() {


### PR DESCRIPTION
変更点
- ページにアクセスしたときの初期表示として、inputタグに更新対象のテキストを表示。
- inputタグに必須のバリデーションを指定。
- 更新の成功時、失敗時に適切な文言を表示。