### PR TITLE
カテゴリー新規作成の実装

### DIFF
--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -138,7 +138,7 @@ const router = new VueRouter({
       component: Categories,
       children: [
         {
-          name: 'categoryManegement',
+          name: 'categoryManagement',
           path: '',
           component: CategoryManagement,
         },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -11,9 +11,52 @@ export default {
     deleteCategoryName: '',
     updateCategoryId: null,
     updateCategoryName: '',
+    category: {
+      id: '',
+      name: '',
+    },
   },
   getters: {
     categoryList: state => state.categoryList,
+  },
+  mutations: {
+    clearMessage(state) {
+      state.errorMessage = '';
+      state.doneMessage = '';
+    },
+    doneGetAllCategories(state, { categories }) {
+      state.categoryList = [...categories];
+    },
+    failFetchCategory(state, { message }) {
+      state.errorMessage = message;
+    },
+    toggleLoading(state) {
+      state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
+    doneDeleteCategory(state) {
+      state.deleteCategoryId = null;
+      state.deleteCategoryName = '';
+      state.doneMessage = 'カテゴリーの削除が完了しました。';
+    },
+    doneGetCategoryDetail(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryName = payload.name;
+    },
+    editedCategoryName(state, { categoryName }) {
+      state.updateCategoryName = categoryName;
+    },
+    doneUpdateCategory(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryId = payload.name;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    doneCreateCategory(state, payload = { message: '成功しました' }) {
+      state.doneMessage = payload.message;
+    },
   },
   actions: {
     clearMessage({ commit }) {
@@ -84,41 +127,26 @@ export default {
         commit('toggleLoading');
       });
     },
-  },
-  mutations: {
-    clearMessage(state) {
-      state.errorMessage = '';
-      state.doneMessage = '';
-    },
-    doneGetAllCategories(state, { categories }) {
-      state.categoryList = [...categories];
-    },
-    failFetchCategory(state, { message }) {
-      state.errorMessage = message;
-    },
-    toggleLoading(state) {
-      state.loading = !state.loading;
-    },
-    confirmDeleteCategory(state, { categoryId, categoryName }) {
-      state.deleteCategoryId = categoryId;
-      state.deleteCategoryName = categoryName;
-    },
-    doneDeleteCategory(state) {
-      state.deleteCategoryId = null;
-      state.deleteCategoryName = '';
-      state.doneMessage = 'カテゴリーの削除が完了しました。';
-    },
-    doneGetCategoryDetail(state, payload) {
-      state.updateCategoryId = payload.id;
-      state.updateCategoryName = payload.name;
-    },
-    editedCategoryName(state, { categoryName }) {
-      state.updateCategoryName = categoryName;
-    },
-    doneUpdateCategory(state, payload) {
-      state.updateCategoryId = payload.id;
-      state.updateCategoryId = payload.name;
-      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    postCategory({ commit, rootGetters }, CategoryName) {
+      commit('toggleLoading');
+
+      const data = new URLSearchParams();
+      data.append('name', CategoryName);
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('doneCreateCategory', { message: 'カテゴリーの追加が完了しました' });
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failFetchCategory', { message: err.message });
+          reject();
+        });
+      });
     },
   },
 };

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -1,10 +1,12 @@
 <template lang="html">
   <div :class="wrapperClasses">
+    <!-- eslint-disable vue/no-v-html -->
     <div
       :class="classes"
       v-html="marked"
     />
   </div>
+  <!-- eslint-enable -->
 </template>
 
 <script>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </section>
     <section class="category-management-list">
@@ -70,6 +71,7 @@ export default {
   methods: {
     updateValue($event) {
       this[$event.target.name] = $event.target.value;
+      // this.$store.dispatch('categories/updateValue', $event.target.value);
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
@@ -86,6 +88,13 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
       this.toggleModal();
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory', this.category).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+        this.category = '';
+      });
     },
   },
 };


### PR DESCRIPTION
カテゴリー新規作成ができる
- 「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性
- カテゴリーの作成に成功したときは、「カテゴリーの追加が完了しました」というメッセージを表示
- カテゴリーの作成に成功したあと、画面右側に表示されているカテゴリー一覧の表示を更新
