### PR TITLE
【02】【コーディング】カテゴリー更新機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -70,6 +70,39 @@ export default {
         });
       });
     },
+    // 更新を押した時にカテゴリー名が入る
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then((response) => {
+        const payload = response.data.category;
+        commit('doneGetCategoryDetail', payload);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
+    },
+    editedCategoryName({ commit }, categoryName) {
+      commit('editedCategoryName', { categoryName });
+    },
+    updateCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', this.state.categories.updateCategoryId);
+      data.append('name', this.state.categories.updateCategoryName);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${this.state.categories.updateCategoryId}`,
+        data,
+      }).then((response) => {
+        const payload = response.data.category;
+        commit('doneUpdateCategory', payload);
+        commit('toggleLoading');
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+        commit('toggleLoading');
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -85,6 +118,22 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
+    doneGetCategoryDetail(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryName = payload.name;
+    },
+    editedCategoryName(state, { categoryName }) {
+      state.updateCategoryName = categoryName;
+      // console.log(categoryName);
+    },
+    doneUpdateCategory(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryId = payload.name;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    displayDoneMessage(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
@@ -93,9 +142,6 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
       state.doneMessage = 'カテゴリーの削除が完了しました。';
-    },
-    displayDoneMessage(state, payload = { message: 'カテゴリーの追加が完了しました。' }) {
-      state.doneMessage = payload.message;
     },
   },
 };

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,11 +12,15 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
+      :value="updateCategoryName"
+      @updateValue="$emit('udpateValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -27,12 +31,14 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+        <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+        <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+
     </div>
   </form>
 </template>
@@ -50,9 +56,21 @@ export default {
     appText: Text,
   },
   props: {
+    updateCategoryName: {
+      type: String,
+      default: '',
+    },
     disabled: {
       type: Boolean,
       default: false,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
     },
     access: {
       type: Object,
@@ -70,7 +88,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,9 +1,14 @@
 <template>
   <div>
     <app-category-edit
+      :update-category-name="updateCategoryName"
       :disabled="loading ? true : false"
       :access="access"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       @clearMessage="clearMessage"
+      @udpateValue="updateValue"
+      @handleSubmit="updateCategory"
     />
   </div>
 </template>
@@ -22,11 +27,35 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+
+    updateCategoryName() {
+      return this.$store.state.categories.updateCategoryName;
+    },
+
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryDetail', id);
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/editedCategoryName', $event.target.value);
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
+    updateCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
+    },
+
   },
 };
 </script>


### PR DESCRIPTION
1. urlは/categories/{id}(コンポーネント自体はすでに実装済みです)
　→完了
2. ページにアクセスしたときの初期表示として、inputタグに更新対象のテキストを表示する
　→完了
3. inputタグにはテキスト入力が必須のバリデーションを指定する(vee-validete)というプラグインを使用しています、詳しくは公式ドキュメントと他のコンポーネントの実装を参照してください
　→完了
4. 3のバリデーションエラーが発生したときは、バリデーションエラー文言を表示(vee-validete)というプラグインを使用しています、詳しくは公式ドキュメントと他のコンポーネントの実装を参照してください
　→完了
5. api通信を行い更新に成功した時は、ハードコードされている「ここに更新成功時のメッセージが入ります」メッセージを適切な文言として表示する
　→完了
6. api通信を行い更新に失敗した時は、ハードコードされている「ここにエラー時のメッセージが入ります」メッセージを適切な文言として表示する
　→完了