### PR TITLE
[01]カテゴリー新規作成の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,6 +85,35 @@ export default {
         commit('toggleLoading');
       });
     },
+    postCategory({ commit, rootGetters }) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        console.log(data);
+        data.append('title', rootGetters['Categories/targetCategory'].title);
+        data.append('content', rootGetters['Categories/targetCategory'].content);
+        data.append('user_id', rootGetters['auth/user'].id);
+        /* eslint-disable max-len */
+        if (rootGetters['Categories/targetCategory'].category.id !== null) {
+          data.append('category_id', rootGetters['Categories/targetCategory'].category.id);
+        }
+        /* eslint-enable max-len */
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/Category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'を作成しました' });
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failRequest', { message: err.message });
+          reject();
+        });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -98,8 +98,7 @@ export default {
           method: 'POST',
           url: '/category',
           data,
-        }).then((response) => {
-          console.log(response);
+        }).then(() => {
           commit('toggleLoading');
           commit('doneTargetCategory', { targetCategoryName });
           resolve();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -88,7 +88,7 @@ export default {
         commit('toggleLoading');
       });
     },
-    postCategory({ dispatch, commit, rootGetters }, targetCategoryName) {
+    postCategory({ commit, rootGetters }, targetCategoryName) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
         commit('toggleLoading');
@@ -98,10 +98,10 @@ export default {
           method: 'POST',
           url: '/category',
           data,
-        }).then(() => {
+        }).then((response) => {
+          console.log(response);
           commit('toggleLoading');
           commit('doneTargetCategory', { targetCategoryName });
-          dispatch('getAllCategories');
           resolve();
         }).catch((err) => {
           commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -90,26 +90,28 @@ export default {
         commit('toggleLoading');
       });
     },
-    postCategory({ commit, rootGetters }) {
-      commit('clearMessage');
-      commit('toggleLoading');
-      const data = new URLSearchParams();
-      data.append('name', this.state.categories.targetCategoryName);
+    postCategory({ commit, rootGetters }, targetCategoryName) {
       return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        // loadingをtrueにする
+        const data = new URLSearchParams();
+        data.append('name', rootGetters['categories/targetCategoryName'].name);
+        // console.log(rootGetters['categories/targetCategoryName'].name);
+        console.log(data.toString());
+        // console.log('token:', rootGetters['auth/token']);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
-          // data: {targetCategory}
-          data: targetCategoryName,
+          data,
         }).then((response) => {
-          // エラー時:response.data.codeが0
-          if (response.data.code === 0) throw new Error(response.data.message);
           console.log(response);
           commit('toggleLoading');
           // loadingをfalseにする
-          commit('displayDoneMessage', { message: 'を作成しました' });
+          commit('doneTargetCategory', { targetCategoryName });
           resolve();
         }).catch((err) => {
+          console.log(err);
           commit('toggleLoading');
           commit('failFetchCategory', { message: err.message });
           reject();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -91,9 +91,9 @@ export default {
         commit('toggleLoading');
         const data = new URLSearchParams();
         console.log(data);
-        data.append('title', rootGetters['Categories/targetCategory'].title);
-        data.append('content', rootGetters['Categories/targetCategory'].content);
-        data.append('user_id', rootGetters['auth/user'].id);
+        // data.append('title', rootGetters['Categories/targetCategory'].title);
+        // data.append('content', rootGetters['Categories/targetCategory'].content);
+        // data.append('user_id', rootGetters['auth/user'].id);
         /* eslint-disable max-len */
         if (rootGetters['Categories/targetCategory'].category.id !== null) {
           data.append('category_id', rootGetters['Categories/targetCategory'].category.id);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -95,14 +95,15 @@ export default {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/categories',
-          data: category,
+          // data: category,
         }).then((response) => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる
           if (response.data.code === 0) throw new Error(response.data.message);
-          console.log('');
-          // commit('toggleLoading');
-          // commit('displayDoneMessage', { message: 'を作成しました' });
-          // resolve();
+          console.log(response.data.code);
+
+          commit('toggleLoading');
+          commit('displayDoneMessage', { message: 'を作成しました' });
+          resolve();
         }).catch((err) => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -142,9 +142,9 @@ export default {
       state.updateCategoryId = payload.name;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
-    doneTargetCategory(state, { targetCategoryName }) {
-      state.targetCategoryName = targetCategoryName;
+    doneTargetCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
+      state.targetCategoryName = '';
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,7 +3,10 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    targetCategory: '',
+    category: {
+      id: null,
+      name: '',
+    },
     loading: false,
     errorMessage: '',
     doneMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -148,7 +148,6 @@ export default {
     },
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
-      state.categoryList.push(state.targetCategoryName);
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -16,6 +16,7 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
+    targetCategory: state => state.targetCategory,
   },
   actions: {
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -144,7 +144,6 @@ export default {
     },
     doneTargetCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
-      state.targetCategoryName = '';
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -104,7 +104,7 @@ export default {
           method: 'POST',
           url: '/category',
           data,
-        }).then((targetCategoryName) => {
+        }).then(() => {
           commit('toggleLoading');
           // loadingをfalseにする
           commit('doneTargetCategory', { targetCategoryName });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,7 +4,6 @@ export default {
   namespaced: true,
   state: {
     targetCategoryName: '',
-    targetCategoryId: null,
     loading: false,
     errorMessage: '',
     doneMessage: '',
@@ -17,7 +16,6 @@ export default {
   getters: {
     categoryList: state => state.categoryList,
     targetCategoryName: state => state.targetCategoryName,
-    // targetCategoryId: state => state.targetCategoryId,
   },
   actions: {
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -96,22 +96,21 @@ export default {
         commit('toggleLoading');
         // loadingをtrueにする
         const data = new URLSearchParams();
-        data.append('name', rootGetters['categories/targetCategoryName'].name);
+        data.append('name', targetCategoryName);
         // console.log(rootGetters['categories/targetCategoryName'].name);
-        console.log(data.toString());
+        // console.log(data.toString());
         // console.log('token:', rootGetters['auth/token']);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
           data,
-        }).then((response) => {
-          console.log(response);
+        }).then((targetCategoryName) => {
           commit('toggleLoading');
           // loadingをfalseにする
           commit('doneTargetCategory', { targetCategoryName });
           resolve();
         }).catch((err) => {
-          console.log(err);
+          // console.log(err);
           commit('toggleLoading');
           commit('failFetchCategory', { message: err.message });
           reject();

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -86,27 +86,20 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }) {
+      commit('clearMessage');
+      commit('toggleLoading');
       return new Promise((resolve, reject) => {
-        commit('clearMessage');
-        commit('toggleLoading');
-        const data = new URLSearchParams();
-        console.log(data);
-        // data.append('title', rootGetters['Categories/targetCategory'].title);
-        // data.append('content', rootGetters['Categories/targetCategory'].content);
-        // data.append('user_id', rootGetters['auth/user'].id);
-        /* eslint-disable max-len */
-        if (rootGetters['Categories/targetCategory'].category.id !== null) {
-          data.append('category_id', rootGetters['Categories/targetCategory'].category.id);
-        }
-        /* eslint-enable max-len */
         axios(rootGetters['auth/token'])({
           method: 'POST',
-          url: '/Category',
-          data,
-        }).then(() => {
-          commit('toggleLoading');
-          commit('displayDoneMessage', { message: 'を作成しました' });
-          resolve();
+          url: '/categories',
+          data: category,
+        }).then((response) => {
+          // NOTE: エラー時はresponse.data.codeが0で返ってくる
+          if (response.data.code === 0) throw new Error(response.data.message);
+          console.log('');
+          // commit('toggleLoading');
+          // commit('displayDoneMessage', { message: 'を作成しました' });
+          // resolve();
         }).catch((err) => {
           commit('toggleLoading');
           commit('failRequest', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,6 +20,7 @@ export default {
   getters: {
     categoryList: state => state.categoryList,
     targetCategoryName: state => state.targetCategoryName,
+    // targetCategoryId: state => state.targetCategoryId,
   },
   actions: {
     clearMessage({ commit }) {
@@ -157,7 +158,9 @@ export default {
     },
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
+      // state.targetCategoryId = targetCategoryId;
       console.log('渡される値:', state.targetCategoryName);
+      // console.log('渡されるid:', state.targetCategoryId);
       console.log('元のカテゴリーリスト:', state.categoryList);
       state.categoryList.push(state.targetCategoryName);
       console.log('追加後のカテゴリーリスト:', state.categoryList);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,6 +3,10 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    // targetCategory: {
+    //   id: null,
+    //   name: '',
+    // },
     targetCategoryName: '',
     loading: false,
     errorMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -15,7 +15,6 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
-    targetCategoryName: state => state.targetCategoryName,
   },
   actions: {
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -155,10 +155,7 @@ export default {
     },
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
-      /* eslint-disable max-len */
-      // state.categoryList = Object.assign({}, ...state.categoryList, { targetCategoryName });
       state.categoryList = state.categoryList.push(targetCategoryName);
-      /* eslint-enable max-len */
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,6 +3,7 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
+    targetCategory: '',
     loading: false,
     errorMessage: '',
     doneMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -72,8 +72,8 @@ export default {
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', this.state.categories.updateCategoryId);
-      data.append('name', this.state.categories.updateCategoryName);
+      data.append('id', this.state.categories.targetCategoryId);
+      data.append('name', this.state.categories.targetCategoryName);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.updateCategoryId}`,
@@ -94,9 +94,10 @@ export default {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/categories',
-          // data: category,
+          data: {targetCategory}
+          // data,
         }).then((response) => {
-          // NOTE: エラー時はresponse.data.codeが0で返ってくる
+          // エラー時はresponse.data.codeが0で返ってくる
           if (response.data.code === 0) throw new Error(response.data.message);
           console.log(response.data.code);
 

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -89,23 +89,25 @@ export default {
     postCategory({ commit, rootGetters }) {
       commit('clearMessage');
       commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', this.state.categories.targetCategoryName);
       return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
-          url: '/categories',
-          data: {targetCategory}
-          // data,
+          url: '/category',
+          // data: {targetCategory}
+          data: targetCategoryName,
         }).then((response) => {
-          // エラー時はresponse.data.codeが0で返ってくる
+          // エラー時:response.data.codeが0
           if (response.data.code === 0) throw new Error(response.data.message);
-          console.log(response.data.code);
-
+          console.log(response);
           commit('toggleLoading');
+          // loadingをfalseにする
           commit('displayDoneMessage', { message: 'を作成しました' });
           resolve();
         }).catch((err) => {
           commit('toggleLoading');
-          commit('failRequest', { message: err.message });
+          commit('failFetchCategory', { message: err.message });
           reject();
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -15,7 +15,7 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
-    targetCategory: state => state.targetCategory,
+    targetCategoryName: state => state.targetCategoryName,
   },
   actions: {
     clearMessage({ commit }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,7 +3,6 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    targetCategoryId: null,
     targetCategoryName: '',
     loading: false,
     errorMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -155,8 +155,14 @@ export default {
     },
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
-      state.categoryList = state.categoryList.push(targetCategoryName);
+      console.log('渡される値:', state.targetCategoryName);
+      console.log('元のカテゴリーリスト:', state.categoryList);
+      state.categoryList.push(state.targetCategoryName);
+      console.log('追加後のカテゴリーリスト:', state.categoryList);
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
+    // initPostCategory(state) {
+    //   state.targetCategoryName = '';
+    // },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -94,9 +94,6 @@ export default {
         commit('toggleLoading');
         const data = new URLSearchParams();
         data.append('name', targetCategoryName);
-        // console.log(rootGetters['categories/targetCategoryName'].name);
-        // console.log(data.toString());
-        // console.log('token:', rootGetters['auth/token']);
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -113,9 +110,6 @@ export default {
         });
       });
     },
-    // initPostCategory({ commit }) {
-    //   commit('initPostCategory');
-    // },
   },
   mutations: {
     clearMessage(state) {
@@ -154,16 +148,8 @@ export default {
     },
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
-      // state.targetCategoryId = targetCategoryId;
-      console.log('渡される値:', state.targetCategoryName);
-      // console.log('渡されるid:', state.targetCategoryId);
-      console.log('元のカテゴリーリスト:', state.categoryList);
       state.categoryList.push(state.targetCategoryName);
-      console.log('追加後のカテゴリーリスト:', state.categoryList);
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
-    // initPostCategory(state) {
-    //   state.targetCategoryName = '';
-    // },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,10 +3,8 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    category: {
-      id: null,
-      name: '',
-    },
+    targetCategoryId: null,
+    targetCategoryName: '',
     loading: false,
     errorMessage: '',
     doneMessage: '',

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -106,17 +106,19 @@ export default {
           data,
         }).then(() => {
           commit('toggleLoading');
-          // loadingをfalseにする
           commit('doneTargetCategory', { targetCategoryName });
+          dispatch('getAllCategories');
           resolve();
         }).catch((err) => {
-          // console.log(err);
           commit('toggleLoading');
           commit('failFetchCategory', { message: err.message });
           reject();
         });
       });
     },
+    // initPostCategory({ commit }) {
+    //   commit('initPostCategory');
+    // },
   },
   mutations: {
     clearMessage(state) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -152,5 +152,12 @@ export default {
       state.updateCategoryId = payload.name;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
+    doneTargetCategory(state, { targetCategoryName }) {
+      state.targetCategoryName = targetCategoryName;
+      /* eslint-disable max-len */
+      state.categoryList = Object.assign({}, ...state.categoryList, { targetCategoryName });
+      /* eslint-enable max-len */
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -3,11 +3,8 @@ import axios from '@Helpers/axiosDefault';
 export default {
   namespaced: true,
   state: {
-    // targetCategory: {
-    //   id: null,
-    //   name: '',
-    // },
     targetCategoryName: '',
+    targetCategoryId: null,
     loading: false,
     errorMessage: '',
     doneMessage: '',
@@ -91,11 +88,10 @@ export default {
         commit('toggleLoading');
       });
     },
-    postCategory({ commit, rootGetters }, targetCategoryName) {
+    postCategory({ dispatch, commit, rootGetters }, targetCategoryName) {
       return new Promise((resolve, reject) => {
         commit('clearMessage');
         commit('toggleLoading');
-        // loadingをtrueにする
         const data = new URLSearchParams();
         data.append('name', targetCategoryName);
         // console.log(rootGetters['categories/targetCategoryName'].name);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -72,8 +72,8 @@ export default {
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', this.state.categories.targetCategoryId);
-      data.append('name', this.state.categories.targetCategoryName);
+      data.append('id', this.state.categories.updateCategoryId);
+      data.append('name', this.state.categories.updateCategoryName);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.updateCategoryId}`,

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -157,7 +157,8 @@ export default {
     doneTargetCategory(state, { targetCategoryName }) {
       state.targetCategoryName = targetCategoryName;
       /* eslint-disable max-len */
-      state.categoryList = Object.assign({}, ...state.categoryList, { targetCategoryName });
+      // state.categoryList = Object.assign({}, ...state.categoryList, { targetCategoryName });
+      state.categoryList = state.categoryList.push(targetCategoryName);
       /* eslint-enable max-len */
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -72,7 +72,7 @@ export default {
   },
   methods: {
     addCategory() {
-      // emitでstoreのactionを呼び出し
+      // emitでpages(親)のメソッドを呼び出し
       if (!this.access.create) return;
       this.$emit('clearMessage');
       // 入力チェック

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -72,10 +72,10 @@ export default {
   },
   methods: {
     addCategory() {
-      console.log('addCategory');
       // emitでstoreのactionを呼び出し
       if (!this.access.create) return;
       this.$emit('clearMessage');
+      // 入力チェック
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -73,7 +73,6 @@ export default {
     addCategory() {
       // emitでpages(親)のメソッドを呼び出し
       if (!this.access.create) return;
-      this.$emit('clearMessage');
       // 入力チェック
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -16,7 +16,6 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
-      @click="addCategory"
     >
       {{ buttonText }}
     </app-button>

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -73,6 +73,7 @@ export default {
   methods: {
     addCategory() {
       console.log('addCategory');
+      // emitでstoreのactionを呼び出し
       if (!this.access.create) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -71,9 +71,7 @@ export default {
   },
   methods: {
     addCategory() {
-      // emitでpages(親)のメソッドを呼び出し
       if (!this.access.create) return;
-      // 入力チェック
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -16,6 +16,7 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
+      @click="addCategory"
     >
       {{ buttonText }}
     </app-button>
@@ -71,6 +72,7 @@ export default {
   },
   methods: {
     addCategory() {
+      console.log('addCategory');
       if (!this.access.create) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -91,6 +91,7 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
+        this.category = '';
         this.$store.dispatch('categories/getAllCategories');
       });
     },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </section>
     <section class="category-management-list">
@@ -86,6 +87,15 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
       this.toggleModal();
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory').then(() => {
+        this.$router.push({
+          path: '/categories',
+          query: { redirect: '/categories' },
+        });
+      });
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -63,6 +63,9 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
+    targetCategoryName() {
+      return this.store.state.categories.targetCategoryName;
+    },
   },
   created() {
     this.$store.dispatch('categories/clearMessage');

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -63,18 +63,7 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
-    // targetCategoryName() {
-    //   return this.store.state.categories.targetCategoryName;
-    // },
-    // targetCategoryId() {
-    //   return this.store.state.categories.targetCategoryId;
-    // }
   },
-  // watch: {
-  //   categoryList() {
-  //     return this.$store.state.categories.categoryList;
-  //   },
-  // },
   created() {
     this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
@@ -100,7 +89,6 @@ export default {
       this.toggleModal();
     },
     handleSubmit() {
-      console.log('入力された値:', this.category);
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category);
     },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -88,16 +88,17 @@ export default {
         });
       this.toggleModal();
     },
-    handleSubmit() {
+    handleSubmit(category) {
+      console.log('入力された値:', category);
       if (this.loading) return;
-      this.$store.dispatch('categories/postCategory').then(() => {
-        this.$router.push({
-          path: '/categories',
-          query: { redirect: '/categories' },
-        });
-        // 異なるURLへ遷移する
+      this.$store.dispatch('categories/postCategory', category)
+        .then(() => {
+          this.$router.push({
+            path: '/categories',
+            query: { redirect: '/categories' },
+          });
         // $router:ルーターインスタンス
-      });
+        });
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -91,17 +91,10 @@ export default {
         });
       this.toggleModal();
     },
-    handleSubmit(category) {
-      console.log('入力された値:', category);
+    handleSubmit() {
+      console.log('入力された値:', this.category);
       if (this.loading) return;
-      this.$store.dispatch('categories/postCategory', category)
-        .then(() => {
-          this.$router.push({
-            path: '/categories',
-            query: { redirect: '/categories' },
-          });
-        // $router:ルーターインスタンス
-        });
+      this.$store.dispatch('categories/postCategory', this.category);
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -95,6 +95,8 @@ export default {
           path: '/categories',
           query: { redirect: '/categories' },
         });
+        // 異なるURLへ遷移する
+        // $router:ルーターインスタンス
       });
     },
   },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -91,6 +91,7 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category);
+      this.$store.dispatch('categories/getAllCategories');
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -63,10 +63,18 @@ export default {
     deleteCategoryName() {
       return this.$store.state.categories.deleteCategoryName;
     },
-    targetCategoryName() {
-      return this.store.state.categories.targetCategoryName;
-    },
+    // targetCategoryName() {
+    //   return this.store.state.categories.targetCategoryName;
+    // },
+    // targetCategoryId() {
+    //   return this.store.state.categories.targetCategoryId;
+    // }
   },
+  // watch: {
+  //   categoryList() {
+  //     return this.$store.state.categories.categoryList;
+  //   },
+  // },
   created() {
     this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -90,8 +90,9 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/postCategory', this.category);
-      this.$store.dispatch('categories/getAllCategories');
+      this.$store.dispatch('categories/postCategory', this.category).then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
     },
   },
 };


### PR DESCRIPTION
変更点：
・ urlは/categories/
・インプットタグ内に入力された値をカテゴリー登録apiを使用して登録
・「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性にする
・カテゴリー作成時「カテゴリーの追加が完了しました」というメッセージ表示
・カテゴリー作成後、カテゴリー一覧の表示を更新

過去に出ていたエラーは修正いたしましたので、ご確認をお願いいたします。