### PR TITLE
タスク02 カテゴリー更新機能の実装(中川美穂)

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -86,6 +86,9 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    editedCategoryName({ commit }, categoryName) {
+      commit('editedCategoryName', { categoryName });
+    },
     // updateCategory({ commit, rootGetters }, updateCategoryName) {
     //   return new Promise((resolve, reject) => {
     //     commit('clearMessage');
@@ -125,6 +128,9 @@ export default {
     getCategoryDetail(state, payload) {
       state.updateCategoryId = payload.id;
       state.updateCategoryName = payload.name;
+    },
+    editedCategoryName(state, { categoryName }) {
+      state.updateCategoryName = categoryName;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -77,9 +77,9 @@ export default {
     getCategoryDetail({ commit, rootGetters }, { id }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
-        url: `/category.${id}`,
+        url: `/category/${id}`,
       }).then((res) => {
-        console.log(res);
+        console.log(res.data.category.name);
         const payload = res.data.category;
         commit('getCategoryDetail', payload);
       }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,25 +74,16 @@ export default {
         });
       });
     },
-    getCategoryDetail({ commit, rootGetters }, updateCategoryId) {
-      return new Promise((resolve, reject) => {
-        commit('clearMessage');
+    getCategoryDetail({ commit, rootGetters }, { categoryId }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category.${categoryId}`,
+      }).then((res) => {
+        const payload = res.data.category;
+        commit('confirmCategoryDetail', payload);
+      }).catch((err) => {
         commit('toggleLoading');
-        const data = new URLSearchParams();
-        data.append('name', updateCategoryId);
-        axios(rootGetters['auth/token'])({
-          method: 'GET',
-          url: '/category',
-          data,
-        }).then(() => {
-          commit('toggleLoading');
-          commit('confirmCategoryDetail', { updateCategoryId });
-          resolve();
-        }).catch((err) => {
-          commit('toggleLoading');
-          commit('failFetchCategory', { message: err.message });
-          reject();
-        });
+        commit('failFetchCategory', { message: err.message });
       });
     },
     // updateCategory({ commit, rootGetters }, updateCategoryName) {
@@ -131,8 +122,9 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    confirmCategoryDetail(state, { categoryId }) {
+    confirmCategoryDetail(state, { categoryId, categoryName }) {
       state.updateCategoryId = categoryId;
+      state.updateCategoryName = categoryName;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,11 +74,12 @@ export default {
         });
       });
     },
-    getCategoryDetail({ commit, rootGetters }, categoryId) {
+    getCategoryDetail({ commit, rootGetters }, { categoryId }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category.${categoryId}`,
       }).then((res) => {
+        console.log(res);
         const payload = res.data.category;
         commit('getCategoryDetail', payload);
       }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -79,7 +79,7 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then((response) => {
-        console.log(response.data.category.name);
+        console.log('GET_response:', response.data.category.name);
         const payload = response.data.category;
         commit('getCategoryDetail', payload);
       }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -89,27 +89,27 @@ export default {
     editedCategoryName({ commit }, categoryName) {
       commit('editedCategoryName', { categoryName });
     },
-    // updateCategory({ commit, rootGetters }, updateCategoryName) {
-    //   return new Promise((resolve, reject) => {
-    //     commit('clearMessage');
-    //     commit('toggleLoading');
-    //     const data = new URLSearchParams();
-    //     data.append('id', updateCategoryId);
-    //     axios(rootGetters['auth/token'])({
-    //       method: 'PUT',
-    //       url: '/category',
-    //       data,
-    //     }).then(() => {
-    //       commit('toggleLoading');
-    //       // commit('updateCategory', { response });
-    //       resolve();
-    //     }).catch((err) => {
-    //       commit('toggleLoading');
-    //       commit('failFetchCategory', { message: err.message });
-    //       reject();
-    //     });
-    //   });
-    // },
+    updateCategory({ commit, rootGetters }, updateCategoryId) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('id', updateCategoryId);
+        axios(rootGetters['auth/token'])({
+          method: 'PUT',
+          url: '/category',
+          data,
+        }).then((response) => {
+          commit('toggleLoading');
+          commit('updateCategory', { response });
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failFetchCategory', { message: err.message });
+          reject();
+        });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -131,6 +131,11 @@ export default {
     },
     editedCategoryName(state, { categoryName }) {
       state.updateCategoryName = categoryName;
+    },
+    updateCategory(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryName = payload.name;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,10 +74,10 @@ export default {
         });
       });
     },
-    getCategoryDetail({ commit, rootGetters }, { categoryId }) {
+    getCategoryDetail({ commit, rootGetters }, { id }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
-        url: `/category.${categoryId}`,
+        url: `/category.${id}`,
       }).then((res) => {
         console.log(res);
         const payload = res.data.category;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,13 +74,13 @@ export default {
         });
       });
     },
-    getCategoryDetail({ commit, rootGetters }, { id }) {
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
-        url: `/category/${id}`,
-      }).then((res) => {
-        console.log(res.data.category.name);
-        const payload = res.data.category;
+        url: `/category/${categoryId}`,
+      }).then((response) => {
+        console.log(response.data.category.name);
+        const payload = response.data.category;
         commit('getCategoryDetail', payload);
       }).catch((err) => {
         commit('failFetchCategory', { message: err.message });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -90,24 +90,21 @@ export default {
       commit('editedCategoryName', { categoryName });
     },
     updateCategory({ commit, rootGetters }, updateCategoryId) {
-      return new Promise((resolve, reject) => {
-        commit('clearMessage');
+      commit('clearMessage');
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', updateCategoryId);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${this.state.categories.updateCategoryId}`,
+        data,
+      }).then((response) => {
+        const payload = response.data.category;
+        commit('updateCategory', payload);
         commit('toggleLoading');
-        const data = new URLSearchParams();
-        data.append('id', updateCategoryId);
-        axios(rootGetters['auth/token'])({
-          method: 'PUT',
-          url: '/category',
-          data,
-        }).then((response) => {
-          commit('toggleLoading');
-          commit('updateCategory', { response });
-          resolve();
-        }).catch((err) => {
-          commit('toggleLoading');
-          commit('failFetchCategory', { message: err.message });
-          reject();
-        });
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+        commit('toggleLoading');
       });
     },
   },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,6 +74,48 @@ export default {
         });
       });
     },
+    getCategoryDetail({ commit, rootGetters }, updateCategoryId) {
+      return new Promise((resolve, reject) => {
+        commit('clearMessage');
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', updateCategoryId);
+        axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('confirmCategoryDetail', { updateCategoryId });
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failFetchCategory', { message: err.message });
+          reject();
+        });
+      });
+    },
+    // updateCategory({ commit, rootGetters }, updateCategoryName) {
+    //   return new Promise((resolve, reject) => {
+    //     commit('clearMessage');
+    //     commit('toggleLoading');
+    //     const data = new URLSearchParams();
+    //     data.append('id', updateCategoryId);
+    //     axios(rootGetters['auth/token'])({
+    //       method: 'PUT',
+    //       url: '/category',
+    //       data,
+    //     }).then(() => {
+    //       commit('toggleLoading');
+    //       // commit('updateCategory', { response });
+    //       resolve();
+    //     }).catch((err) => {
+    //       commit('toggleLoading');
+    //       commit('failFetchCategory', { message: err.message });
+    //       reject();
+    //     });
+    //   });
+    // },
   },
   mutations: {
     clearMessage(state) {
@@ -88,6 +130,9 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmCategoryDetail(state, { categoryId }) {
+      state.updateCategoryId = categoryId;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -86,14 +86,18 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
-    editedCategoryName({ commit }, categoryName) {
-      commit('editedCategoryName', { categoryName });
+    editedCategoryName({ commit }, targetCategoryName) {
+      commit('editedCategoryName', { targetCategoryName });
+      // stateのupdateCategoryNameに[inputに入力された値]を代入
+      console.log('editedCategoryNameに渡った値:', targetCategoryName);
     },
-    updateCategory({ commit, rootGetters }, updateCategoryId) {
+    updateCategory({ commit, rootGetters }) {
       commit('clearMessage');
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', updateCategoryId);
+      data.append('id', this.state.categories.updateCategoryId);
+      data.append('name', this.state.categories.updateCategoryName);
+      console.log('updateCategoryのdata:', data);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.updateCategoryId}`,

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -79,7 +79,6 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then((response) => {
-        console.log('GET_response:', response.data.category.name);
         const payload = response.data.category;
         commit('getCategoryDetail', payload);
       }).catch((err) => {
@@ -88,8 +87,6 @@ export default {
     },
     editedCategoryName({ commit }, targetCategoryName) {
       commit('editedCategoryName', { targetCategoryName });
-      // stateのupdateCategoryNameに[inputに入力された値]を代入
-      console.log('editedCategoryNameに渡った値:', targetCategoryName);
     },
     updateCategory({ commit, rootGetters }) {
       commit('clearMessage');
@@ -97,7 +94,6 @@ export default {
       const data = new URLSearchParams();
       data.append('id', this.state.categories.updateCategoryId);
       data.append('name', this.state.categories.updateCategoryName);
-      console.log('updateCategoryのdata:', data);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.updateCategoryId}`,
@@ -107,7 +103,6 @@ export default {
         commit('updateCategory', payload);
         commit('toggleLoading');
       }).catch((err) => {
-        console.log('エラー：', err);
         commit('failFetchCategory', { message: err.message });
         commit('toggleLoading');
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -107,6 +107,7 @@ export default {
         commit('updateCategory', payload);
         commit('toggleLoading');
       }).catch((err) => {
+        console.log('エラー：', err);
         commit('failFetchCategory', { message: err.message });
         commit('toggleLoading');
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -126,8 +126,8 @@ export default {
       state.updateCategoryId = payload.id;
       state.updateCategoryName = payload.name;
     },
-    editedCategoryName(state, { categoryName }) {
-      state.updateCategoryName = categoryName;
+    editedCategoryName(state, { targetCategoryName }) {
+      state.updateCategoryName = targetCategoryName;
     },
     updateCategory(state, payload) {
       state.updateCategoryId = payload.id;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -74,15 +74,14 @@ export default {
         });
       });
     },
-    getCategoryDetail({ commit, rootGetters }, { categoryId }) {
+    getCategoryDetail({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category.${categoryId}`,
       }).then((res) => {
         const payload = res.data.category;
-        commit('confirmCategoryDetail', payload);
+        commit('getCategoryDetail', payload);
       }).catch((err) => {
-        commit('toggleLoading');
         commit('failFetchCategory', { message: err.message });
       });
     },
@@ -122,9 +121,9 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
-    confirmCategoryDetail(state, { categoryId, categoryName }) {
-      state.updateCategoryId = categoryId;
-      state.updateCategoryName = categoryName;
+    getCategoryDetail(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryName = payload.name;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,6 +12,7 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -18,7 +18,7 @@
       data-vv-as="カテゴリー名"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      :error-messages="errors.collect('category')"
+      :error-messages="errors.collect('updateCategory')"
       :value="updateCategoryName"
       @updateValue="$emit('udpateValue', $event)"
     />

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -70,7 +70,8 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('updateCategory');
+        // 親(pages)のメソッド呼び出し
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -19,7 +19,7 @@
       placeholder="カテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
-      :value="categoryName"
+      :value="updateCategoryName"
       @updateValue="$emit('udpateValue', $event)"
     />
     <app-button

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -17,7 +17,10 @@
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
+      :value="updateCategoryName"
+      @updateValue="$emit('udpateValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -70,6 +73,7 @@ export default {
     handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
+      console.log(this);
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('updateCategory');
         // 親(pages)のメソッド呼び出し

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -18,8 +18,8 @@
       type="text"
       placeholder="カテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
-      :error-messages="errors.collect('updateCategory')"
-      :value="updateCategoryName"
+      :error-messages="errors.collect('category')"
+      :value="categoryName"
       @updateValue="$emit('udpateValue', $event)"
     />
     <app-button
@@ -61,6 +61,10 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    updateCategoryName: {
+      type: String,
+      default: '',
     },
   },
   computed: {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -87,6 +87,7 @@ export default {
       this.$emit('clearMessage');
       console.log('入力された値:', this.updateCategoryName);
       this.$validator.validate().then((valid) => {
+        console.log('バリデート結果:', valid);
         if (valid) this.$emit('handleSubmit');
         // 親(pages)のメソッド呼び出し
       });

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -87,7 +87,7 @@ export default {
       this.$emit('clearMessage');
       console.log('入力された値:', this.updateCategoryName);
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('updateCategory');
+        if (valid) this.$emit('handleSubmit');
         // 親(pages)のメソッド呼び出し
       });
     },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -15,9 +15,9 @@
       v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
+      data-vv-as="カテゴリー名"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as="カテゴリー名"
       :error-messages="errors.collect('category')"
       :value="updateCategoryName"
       @updateValue="$emit('udpateValue', $event)"
@@ -85,7 +85,7 @@ export default {
     handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
-      console.log('updateCategoryName:', this.updateCategoryName);
+      console.log('入力された値:', this.updateCategoryName);
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('updateCategory');
         // 親(pages)のメソッド呼び出し

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -85,7 +85,7 @@ export default {
     handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
-      console.log(this);
+      console.log('updateCategoryName:', this.updateCategoryName);
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('updateCategory');
         // 親(pages)のメソッド呼び出し

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -66,6 +66,14 @@ export default {
       type: String,
       default: '',
     },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -85,11 +85,8 @@ export default {
     handleSubmit() {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
-      console.log('入力された値:', this.updateCategoryName);
       this.$validator.validate().then((valid) => {
-        console.log('バリデート結果:', valid);
         if (valid) this.$emit('handleSubmit');
-        // 親(pages)のメソッド呼び出し
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -31,12 +31,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -3,6 +3,8 @@
     <app-category-edit
       :disabled="loading ? true : false"
       :access="access"
+      :category-id="categoryId"
+      :category-name="categoryName"
       @clearMessage="clearMessage"
     />
   </div>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -25,6 +25,14 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    categoryId() {
+      const { id } = this.$store.state.categories.updateCategoryId;
+      return id;
+    },
+    categoryName() {
+      const { name } = this.$store.state.categories.updateCategoryName;
+      return name;
+    },
   },
   created() {
     const { id } = this.$route.params;

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -29,10 +29,10 @@ export default {
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+      console.log(this);
     },
     updateCategory() {
-      console.log(this);
-      this.$store.dispatch('categories/updateCategory');
+      this.$store.dispatch('categories/getCategoryDetail');
       // storeのaction呼び出し
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -25,14 +25,17 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
-    categoryId() {
-      const { id } = this.$store.state.categories.updateCategoryId;
-      return id;
+    updateCategoryName() {
+      return this.$store.state.categories.updateCategoryName;
     },
-    categoryName() {
-      const { name } = this.$store.state.categories.updateCategoryName;
-      return name;
-    },
+    // categoryId() {
+    //   const { id } = this.$store.state.categories.updateCategoryId;
+    //   return id;
+    // },
+    // categoryName() {
+    //   const { name } = this.$store.state.categories.updateCategoryName;
+    //   return name;
+    // },
   },
   created() {
     const { id } = this.$route.params;

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -34,7 +34,7 @@ export default {
       console.log(this);
       this.$store.dispatch('categories/updateCategory');
       // storeのaction呼び出し
-    }
+    },
   },
 };
 </script>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -30,14 +30,12 @@ export default {
     updateCategoryName() {
       return this.$store.state.categories.updateCategoryName;
     },
-    // categoryId() {
-    //   const { id } = this.$store.state.categories.updateCategoryId;
-    //   return id;
-    // },
-    // categoryName() {
-    //   const { name } = this.$store.state.categories.updateCategoryName;
-    //   return name;
-    // },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
   created() {
     const { id } = this.$route.params;

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -26,13 +26,18 @@ export default {
       return this.$store.state.categories.loading;
     },
   },
+  created() {
+    const { id } = this.$route.params;
+    console.log('categoryId:', id);
+    this.$store.dispatch('categories/getCategoryDetail', { id });
+  },
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
-      console.log(this);
+      // console.log(this);
     },
     updateCategory() {
-      this.$store.dispatch('categories/getCategoryDetail');
+      this.$store.dispatch('categories/updateCategory');
       // storeのaction呼び出し
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -40,6 +40,9 @@ export default {
     this.$store.dispatch('categories/getCategoryDetail', { id });
   },
   methods: {
+    // updateValue() {
+    //   this.$store.dispatch('categories/editedCategpryName');
+    // }
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
       // console.log(this);

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -8,7 +8,7 @@
       :access="access"
       @udpateValue="updateValue"
       @clearMessage="clearMessage"
-      @handleSubmit="updateCategory"
+      @handleSubmit="handleSubmit"
     />
   </div>
 </template>
@@ -45,12 +45,13 @@ export default {
   },
   methods: {
     updateValue($event) {
+      console.log('updateValueのthis:', this.updateCategoryName);
       this.$store.dispatch('categories/editedCategoryName', $event.target.value);
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    updateCategory() {
+    handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/updateCategory');
       // storeのaction呼び出し

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -6,6 +6,7 @@
       :category-id="categoryId"
       :category-name="categoryName"
       @clearMessage="clearMessage"
+      @updateCategory="updateCategory"
     />
   </div>
 </template>
@@ -29,6 +30,11 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
+    updateCategory(){
+      console.log(this);
+      this.$store.dispatch('categories/updateCategory');
+      // storeのaction呼び出し
+    }
   },
 };
 </script>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -44,14 +44,14 @@ export default {
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
-    // updateValue() {
-    //   this.$store.dispatch('categories/editedCategpryName');
-    // }
+    updateValue($event) {
+      this.$store.dispatch('categories/editedCategoryName', $event.target.value);
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
-      // console.log(this);
     },
     updateCategory() {
+      if (this.loading) return;
       this.$store.dispatch('categories/updateCategory');
       // storeのaction呼び出し
     },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,12 +1,14 @@
 <template>
   <div>
     <app-category-edit
+      :update-category-name="updateCategoryName"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       :disabled="loading ? true : false"
       :access="access"
-      :category-id="categoryId"
-      :category-name="categoryName"
+      @udpateValue="updateValue"
       @clearMessage="clearMessage"
-      @updateCategory="updateCategory"
+      @handleSubmit="updateCategory"
     />
   </div>
 </template>

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -40,7 +40,8 @@ export default {
   created() {
     const { id } = this.$route.params;
     console.log('categoryId:', id);
-    this.$store.dispatch('categories/getCategoryDetail', { id });
+    this.$store.dispatch('categories/getCategoryDetail', id);
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     // updateValue() {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -30,7 +30,7 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    updateCategory(){
+    updateCategory() {
       console.log(this);
       this.$store.dispatch('categories/updateCategory');
       // storeのaction呼び出し

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -39,13 +39,11 @@ export default {
   },
   created() {
     const { id } = this.$route.params;
-    console.log('categoryId:', id);
     this.$store.dispatch('categories/getCategoryDetail', id);
     this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     updateValue($event) {
-      console.log('updateValueのthis:', this.updateCategoryName);
       this.$store.dispatch('categories/editedCategoryName', $event.target.value);
     },
     clearMessage() {
@@ -54,7 +52,6 @@ export default {
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('categories/updateCategory');
-      // storeのaction呼び出し
     },
   },
 };


### PR DESCRIPTION
[変更点]
1. ページアクセス時の初期表示として、inputタグに更新対象のテキストを表示する
2. inputタグにはテキスト入力必須のバリデーションを指定する(vee-valideteというプラグインを使用)
3. バリデーションエラー発生時にバリデーションエラー文言を表示(vee-valideteというプラグインを使用)
4. api通信を行い更新に成功した時は、ハードコードされている「ここに更新成功時のメッセージが入ります」メッセージを適切な文言として表示
5. api通信を行い更新に失敗した時は、ハードコードされている「ここにエラー時のメッセージが入ります」メッセージを適切な文言として表示

ご確認をお願いいたします。