### PR TITLE
[タスク03] カテゴリー一覧の機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -49,7 +49,6 @@ export default {
           url: `/category/${this.state.categories.deleteCategoryId}`,
         }).then((response) => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
-          console.log('response.data.code:', response.data.code);
           if (response.data.code === 0) throw new Error(response.data.message);
 
           commit('doneDeleteCategory');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -36,6 +36,10 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
+      // console.log(categoryId, categoryName);
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
     deleteCategory({ commit, rootGetters }, categoryId) {
       return new Promise((resolve) => {
         axios(rootGetters['auth/token'])({
@@ -136,6 +140,7 @@ export default {
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
+      console.log('削除対象:', state.deleteCategoryName);
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,9 +20,21 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    getAllCategories({ commit }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+    getAllCategories({ commit, rootGetters }) {
+      const payload = { categories: [] };
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then((response) => {
+        const categoriesData = response.data.categories;
+        categoriesData.forEach((val) => {
+          // console.log('forEachのval:', val);
+          payload.categories.push(val);
+        });
+        commit('doneGetAllCategories', payload);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     deleteCategory({ commit, rootGetters }, categoryId) {
       return new Promise((resolve) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -41,6 +41,7 @@ export default {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
     deleteCategory({ commit, rootGetters }, categoryId) {
+      console.log(categoryId);
       return new Promise((resolve) => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
@@ -140,7 +141,6 @@ export default {
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
-      console.log('削除対象:', state.deleteCategoryName);
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -15,8 +15,6 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
-    deleteCategoryId: state => state.deleteCategoryId,
-    // ↑追加しなくてもいい（DELETEリクエスト時のurl指定でrootGettersを使いたい場合のみ必要）
   },
   actions: {
     clearMessage({ commit }) {
@@ -31,7 +29,6 @@ export default {
         }).then((response) => {
           const categoriesData = response.data.categories;
           categoriesData.forEach((val) => {
-            // console.log('forEachのval:', val);
             payload.categories.push(val);
           });
           commit('doneGetAllCategories', payload);
@@ -43,15 +40,13 @@ export default {
       });
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
-      // console.log(categoryId, categoryName);
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
     deleteCategory({ commit, rootGetters }) {
       return new Promise((resolve) => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
-          url: `/category/${rootGetters['categories/deleteCategoryId']}`,
-          // url: `/category/${this.state.categories.deleteCategoryId}`,
+          url: `/category/${this.state.categories.deleteCategoryId}`,
         }).then((response) => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
           console.log('response.data.code:', response.data.code);

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -25,6 +25,7 @@
               underline
               small
               hover-opacity
+              :to="`/articles?category=${category.name}`"
             >
               このカテゴリーの記事
             </app-router-link>

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -121,8 +121,6 @@ export default {
       this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
-      // console.log('削除する対象:', categoryId);
-      // console.log('!this.access.delete:', !this.access.delete);
       if (!this.access.delete) return;
       this.$emit('deleteCategory');
     },

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -34,6 +34,7 @@
               theme-color
               underline
               hover-opacity
+              :to="`/categories/${category.id}`"
             >
               更新
             </app-router-link>

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -45,7 +45,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(`${category.id}`, `${category.name}`)"
             >
               削除
             </app-button>
@@ -112,9 +112,9 @@ export default {
     },
   },
   methods: {
-    openModal() {
+    openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
       if (!this.access.delete) return;

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -67,7 +67,7 @@
           theme-color
           tag="p"
         >
-          ここに削除するカテゴリー名が入ります
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -109,6 +109,10 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    deleteCategoryName: {
+      type: String,
+      default: '',
     },
   },
   methods: {

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -121,8 +121,10 @@ export default {
       this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
+      // console.log('削除する対象:', categoryId);
+      // console.log('!this.access.delete:', !this.access.delete);
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('deleteCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -75,6 +75,12 @@ export default {
       this.$store.dispatch('categories/clearMessage');
     },
     openModal(categoryId, categoryName) {
+      // console.log('categoryId:', categoryId);
+      // console.log('categoryName:', categoryName);
+      /* eslint-disable max-len */
+      this.$store.dispatch('categories/confirmDeleteCategory', { categoryId, categoryName });
+      /* eslint-enable max-len */
+      this.toggleModal();
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -19,6 +19,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @deleteCategory="deleteCategory"
       />
     </section>
   </div>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -82,14 +82,10 @@ export default {
       this.toggleModal();
     },
     deleteCategory() {
-      // this.$store.dispatch('categories/deleteCategory');
-      // this.$store.dispatch('categories/getAllCategories');
-      // this.toggleModal();
       this.$store.dispatch('categories/deleteCategory').then(() => {
-        this.$store.dispatch('categories/getAllCategories').then(() => {
-          this.toggleModal();
-        });
+        this.$store.dispatch('categories/getAllCategories');
       });
+      this.toggleModal();
     },
     handleSubmit() {
       if (this.loading) return;

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -75,11 +75,13 @@ export default {
       this.$store.dispatch('categories/clearMessage');
     },
     openModal(categoryId, categoryName) {
-      // console.log('categoryId:', categoryId);
-      // console.log('categoryName:', categoryName);
       /* eslint-disable max-len */
       this.$store.dispatch('categories/confirmDeleteCategory', { categoryId, categoryName });
       /* eslint-enable max-len */
+      this.toggleModal();
+    },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory');
       this.toggleModal();
     },
     handleSubmit() {

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -82,8 +82,14 @@ export default {
       this.toggleModal();
     },
     deleteCategory() {
-      this.$store.dispatch('categories/deleteCategory');
-      this.toggleModal();
+      // this.$store.dispatch('categories/deleteCategory');
+      // this.$store.dispatch('categories/getAllCategories');
+      // this.toggleModal();
+      this.$store.dispatch('categories/deleteCategory').then(() => {
+        this.$store.dispatch('categories/getAllCategories').then(() => {
+          this.toggleModal();
+        });
+      });
     },
     handleSubmit() {
       if (this.loading) return;


### PR DESCRIPTION
[実装内容]
1. urlは/categories
2. ページにアクセスしたときの初期表示として、カテゴリー一覧APIから取得したデータを基にカテゴリーの一覧を表示
3. 「カテゴリー名」のテーブルに取得したカテゴリーの一覧を表示
4. 「このカテゴリーの記事」のリンクをクリックすると、該当のカテゴリーに属している記事一覧を表示
5. 「更新」ボタンをクリックすると、そのカテゴリーの詳細・編集画面に遷移
6. 「削除」 ボタンをクリックして表示されるモーダル内に、削除対象のカテゴリー名を表示
7. モーダルの「削除する」ボタンをクリックしたら、6で表示されているカテゴリーが削除され、その後にモーダルが閉じ削除された状態のカテゴリー一覧を表示

上記内容の処理を実装しました。恐れ入りますが、ご確認をお願いいたします。