### PR TITLE
[タスク04]ドキュメント新規作成の機能実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,6 +4432,11 @@
         "color-name": "^1.0.0"
       }
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
@@ -5225,6 +5230,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
       "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -9928,6 +9938,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
     "lazy": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
@@ -10687,6 +10702,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11544,6 +11564,11 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "4.0.0",
@@ -13800,6 +13825,91 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+          "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -14375,6 +14485,11 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "marked": "^0.7.0",
     "morgan": "^1.9.1",
     "pm2": "^3.5.0",
+    "sanitize-html": "^2.4.0",
     "vee-validate": "^2.2.7",
     "vue": "^2.6.6",
     "vue-router": "^3.0.3",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5,6 +5,7 @@ import 'highlight.js/styles/gruvbox-dark.css';
 import VeeValidate, { Validator } from 'vee-validate';
 import ja from 'vee-validate/dist/locale/ja';
 import vueSmoothScroll from 'vue-smoothscroll';
+import sanitizeHtml from 'sanitize-html';
 
 import App from '@Pages';
 import AppModal from '@Components/atoms/Modal';
@@ -15,6 +16,7 @@ Validator.localize('ja', ja);
 Vue.use(VeeValidate, { locale: ja });
 Vue.use(vueSmoothScroll);
 Vue.component('app-modal', AppModal);
+Vue.prototype.$sanitize = sanitizeHtml;
 
 new Vue({
   el: '#app',

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -10,6 +10,7 @@
 <script>
 import marked from 'marked';
 import hljs from 'highlight.js';
+import sanitizeHtml from 'sanitize-html';
 
 export default {
   props: {
@@ -57,14 +58,6 @@ export default {
       renderer.code = (code, lang) => `<pre class="hljs"><code class="language-${lang}">${hljs.highlightAuto(code, [lang]).value}</code></pre>`;
       renderer.em = text => `<span class="attention">${text}</span>`;
 
-      /* eslint-disable max-len */
-      const target = this.markdownContent.replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-      /* eslint-enable max-len */
-
       marked.setOptions({
         renderer,
         /* renderer: new marked.Renderer(), */
@@ -72,8 +65,13 @@ export default {
         breaks: false,
         smartLists: true,
       });
-      return marked(target);
-      // return marked(this.markdownContent);
+      console.log('変更前:', this.markdownContent);
+      // const target = sanitizeHtml(this.markdownContent);
+      // console.log(target);
+      // return marked(target);
+      const target = marked(this.markdownContent);
+      console.log(target);
+      return sanitizeHtml(target);
     },
   },
   mounted() {

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -66,12 +66,11 @@ export default {
         smartLists: true,
       });
       console.log('変更前:', this.markdownContent);
-      // const target = sanitizeHtml(this.markdownContent);
-      // console.log(target);
-      // return marked(target);
-      const target = marked(this.markdownContent);
-      console.log(target);
-      return sanitizeHtml(target);
+      // const target = marked(this.markdownContent);
+      // console.log('変更後:', target);
+      // console.log(sanitizeHtml(target, { allowedTags: ['br', 'h1'] }));
+      // return sanitizeHtml(target, { allowedTags: ['h1', 'img'] });
+      return marked(this.markdownContent);
     },
   },
   mounted() {

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -57,6 +57,15 @@ export default {
       renderer.code = (code, lang) => `<pre class="hljs"><code class="language-${lang}">${hljs.highlightAuto(code, [lang]).value}</code></pre>`;
       renderer.em = text => `<span class="attention">${text}</span>`;
 
+      /* eslint-disable max-len */
+      this.markdownContent
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+      /* eslint-enable max-len */
+
       marked.setOptions({
         renderer,
         /* renderer: new marked.Renderer(), */

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -58,8 +58,7 @@ export default {
       renderer.em = text => `<span class="attention">${text}</span>`;
 
       /* eslint-disable max-len */
-      this.markdownContent
-        .replace(/&/g, '&amp;')
+      const target = this.markdownContent.replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
@@ -73,7 +72,8 @@ export default {
         breaks: false,
         smartLists: true,
       });
-      return marked(this.markdownContent);
+      return marked(target);
+      // return marked(this.markdownContent);
     },
   },
   mounted() {

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -65,12 +65,9 @@ export default {
         breaks: false,
         smartLists: true,
       });
-      console.log('変更前:', this.markdownContent);
-      // const target = marked(this.markdownContent);
-      // console.log('変更後:', target);
-      // console.log(sanitizeHtml(target, { allowedTags: ['br', 'h1'] }));
-      // return sanitizeHtml(target, { allowedTags: ['h1', 'img'] });
-      return marked(this.markdownContent);
+      const target = marked(this.markdownContent);
+      return sanitizeHtml(target, { allowedTags: ['h1'] });
+      // ※allowedTagsで有効にしたいタグを指定可
     },
   },
   mounted() {

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -158,7 +158,6 @@ export default ({
       if (!this.access.edit) return;
       this.$validator.validate().then((valid) => {
         console.log('valid(trueならpagesのhandleSubmitがemitされる):', valid);
-        console.log('this=vueコンポーネント:', this);
         if (valid) this.$emit('handleSubmit');
       });
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -72,6 +72,18 @@ export default ({
       type: Array,
       default: () => [],
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
   },
 });
 </script>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div class="article-edit">
+  <div class="article-post">
     <div v-if="errorMessage" class="article-post__notice--error">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
@@ -8,7 +8,10 @@
         <app-heading :level="1">
           記事の新規作成
         </app-heading>
-        <app-heading :level="2">
+        <app-heading
+          :level="2"
+          class="article-post-editor-title"
+        >
           カテゴリーの選択
         </app-heading>
         <app-select
@@ -35,7 +38,10 @@
             {{ category.name }}
           </option>
         </app-select>
-        <app-heading :level="2">
+        <app-heading
+          :level="2"
+          class="article-post-editor-title"
+        >
           タイトル・本文
         </app-heading>
         <div class="article-post-form">

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -194,5 +194,8 @@ export default ({
   &-submit {
     margin-top: 16px;
   }
+  &__notice--error {
+    margin-bottom: 16px;
+  }
 }
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -87,3 +87,13 @@ export default ({
   },
 });
 </script>
+
+<style lang="postcss" scoped>
+.article-post {
+  display: flex;
+  height: 100%;
+  &-preview {
+    /* width: 50%; */
+  }
+}
+</style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,3 +1,37 @@
+<template lang="html">
+  <div>
+    <app-heading :level="1">
+      記事の新規作成
+    </app-heading>
+    <app-heading :level="2">
+      カテゴリーの選択
+    </app-heading>
+    <app-select
+      v-validate="'required'"
+      name="category"
+      data-vv-as="カテゴリー"
+      :value="currentCategoryName"
+      :error-messages="errors.collect('category')"
+    >
+      <option
+        value=""
+        selected
+        disabled
+      >
+        ---
+      </option>
+      <option
+        v-for="(category) in categoryList"
+        :key="category.id"
+        :value="category.name"
+        :selected="currentCategoryName === category.name ? true : false "
+      >
+        {{ category.name }}
+      </option>
+    </app-select>
+  </div>
+</template>
+
 <script>
 import {
   Heading, Input, Textarea, MarkdownPreview, Button, Select, Text,

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -158,6 +158,7 @@ export default ({
       if (!this.access.edit) return;
       this.$validator.validate().then((valid) => {
         console.log('valid(trueならpagesのhandleSubmitがemitされる):', valid);
+        console.log('this=vueコンポーネント:', this);
         if (valid) this.$emit('handleSubmit');
       });
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -47,5 +47,15 @@ export default ({
     appSelect: Select,
     appText: Text,
   },
+  props: {
+    currentCategoryName: {
+      type: String,
+      default: '',
+    },
+    categoryList: {
+      type: Array,
+      default: () => [],
+    },
+  },
 });
 </script>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -157,7 +157,6 @@ export default ({
     handleSubmit() {
       if (!this.access.edit) return;
       this.$validator.validate().then((valid) => {
-        console.log('valid(trueならpagesのhandleSubmitがemitされる):', valid);
         if (valid) this.$emit('handleSubmit');
       });
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -174,10 +174,25 @@ export default ({
   &__columns {
   display: flex;
   height: 100%;
-  /* align-items: flex-end; */
+  justify-content: space-between;
+  align-items: flex-start;
   }
   &-preview {
-    /* width: 30%; */
+    margin-left: 2%;
+    width: 48%;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+  &-editor {
+    width: 50%;
+    padding-right: 2%;
+    border-right: 1px solid #ccc;
+    &-title {
+      margin-top: 16px;
+    }
+  }
+  &-form {
+    margin-top: 20px;
   }
   &-submit {
     margin-top: 16px;

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -142,6 +142,14 @@ export default ({
       return this.access.edit && !this.loading;
     },
   },
+  methods: {
+    handleSubmit() {
+      if (!this.access.edit) return;
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+  },
 });
 </script>
 

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,0 +1,5 @@
+<script>
+import {
+  Heading, Input, Textarea, MarkdownPreview, Button, Select, Text,
+} from '@Components/atoms';
+</script>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -111,10 +111,6 @@ export default ({
     appText: Text,
   },
   props: {
-    // articleId: {
-    //   type: Number,
-    //   default: 0,
-    // },
     articleTitle: {
       type: String,
       default: '',

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div class="article-edit">
     <div v-if="errorMessage" class="article-post__notice--error">
-      <app-text bg-danger>{{ errorMessage }}</app-text>
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
     <div class="article-post__columns">
       <section class="article-post-editor">

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,40 +1,79 @@
 <template lang="html">
-  <div>
-    <app-heading :level="1">
-      記事の新規作成
-    </app-heading>
-    <app-heading :level="2">
-      カテゴリーの選択
-    </app-heading>
-    <app-select
-      v-validate="'required'"
-      name="category"
-      data-vv-as="カテゴリー"
-      :value="currentCategoryName"
-      :error-messages="errors.collect('category')"
-    >
-      <option
-        value=""
-        selected
-        disabled
+  <div class="article-post">
+    <section class="article-post-editor">
+      <app-heading :level="1">
+        記事の新規作成
+      </app-heading>
+      <app-heading :level="2">
+        カテゴリーの選択
+      </app-heading>
+      <app-select
+        v-validate="'required'"
+        name="category"
+        data-vv-as="カテゴリー"
+        :value="currentCategoryName"
+        :error-messages="errors.collect('category')"
+        @updateValue="$emit('selectedArticleCategory', $event)"
       >
-        ---
-      </option>
-      <option
-        v-for="(category) in categoryList"
-        :key="category.id"
-        :value="category.name"
-        :selected="currentCategoryName === category.name ? true : false "
-      >
-        {{ category.name }}
-      </option>
-    </app-select>
+        <option
+          value=""
+          selected
+          disabled
+        >
+          ---
+        </option>
+        <option
+          v-for="(category) in categoryList"
+          :key="category.id"
+          :value="category.name"
+          :selected="currentCategoryName === category.name ? true : false "
+        >
+          {{ category.name }}
+        </option>
+      </app-select>
+      <app-heading :level="2">
+        タイトル・本文
+      </app-heading>
+      <app-input
+        v-validate="'required'"
+        name="title"
+        type="text"
+        placeholder="記事のタイトルを入力してください。"
+        white-bg
+        data-vv-as="記事のタイトル"
+        :error-messages="errors.collect('title')"
+        :value="articleTitle"
+        @updateValue="$emit('editedTitle', $event)"
+      />
+      <app-textarea
+        v-validate="'required'"
+        name="content"
+        placeholder="記事の本文をマークダウン記法で入力してください。"
+        white-bg
+        data-vv-as="記事の本文"
+        :error-messages="errors.collect('content')"
+        :value="articleContent"
+        @updateValue="$emit('editedContent', $event)"
+      />
+    </section>
+
+    <article class="article-post-preview">
+      <app-markdown-preview
+        :markdown-content="markdownContent"
+      />
+    </article>
   </div>
 </template>
 
 <script>
 import {
-  Heading, Input, Textarea, MarkdownPreview, Button, Select, Text,
+  Heading,
+  Input,
+  Textarea,
+  MarkdownPreview,
+  // Button,
+  Select,
+  // Text,
 } from '@Components/atoms';
 
 export default ({

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,76 +1,85 @@
 <template lang="html">
-  <div class="article-post">
-    <section class="article-post-editor">
-      <app-heading :level="1">
-        記事の新規作成
-      </app-heading>
-      <app-heading :level="2">
-        カテゴリーの選択
-      </app-heading>
-      <app-select
-        v-validate="'required'"
-        name="category"
-        data-vv-as="カテゴリー"
-        :value="currentCategoryName"
-        :error-messages="errors.collect('category')"
-        @updateValue="$emit('selectedArticleCategory', $event)"
-      >
-        <option
-          value=""
-          selected
-          disabled
+  <div class="article-edit">
+    <div v-if="errorMessage" class="article-post__notice--error">
+      <app-text bg-danger>{{ errorMessage }}</app-text>
+    </div>
+    <div class="article-post__columns">
+      <section class="article-post-editor">
+        <app-heading :level="1">
+          記事の新規作成
+        </app-heading>
+        <app-heading :level="2">
+          カテゴリーの選択
+        </app-heading>
+        <app-select
+          v-validate="'required'"
+          name="category"
+          data-vv-as="カテゴリー"
+          :value="currentCategoryName"
+          :error-messages="errors.collect('category')"
+          @updateValue="$emit('selectedArticleCategory', $event)"
         >
-          ---
-        </option>
-        <option
-          v-for="(category) in categoryList"
-          :key="category.id"
-          :value="category.name"
-          :selected="currentCategoryName === category.name ? true : false "
+          <option
+            value=""
+            selected
+            disabled
+          >
+            ---
+          </option>
+          <option
+            v-for="(category) in categoryList"
+            :key="category.id"
+            :value="category.name"
+            :selected="currentCategoryName === category.name ? true : false "
+          >
+            {{ category.name }}
+          </option>
+        </app-select>
+        <app-heading :level="2">
+          タイトル・本文
+        </app-heading>
+        <div class="article-post-form">
+          <app-input
+            v-validate="'required'"
+            name="title"
+            type="text"
+            placeholder="記事のタイトルを入力してください。"
+            white-bg
+            data-vv-as="記事のタイトル"
+            :error-messages="errors.collect('title')"
+            :value="articleTitle"
+            @updateValue="$emit('editedTitle', $event)"
+          />
+        </div>
+        <div class="article-post-form">
+          <app-textarea
+            v-validate="'required'"
+            name="content"
+            placeholder="記事の本文をマークダウン記法で入力してください。"
+            white-bg
+            data-vv-as="記事の本文"
+            :error-messages="errors.collect('content')"
+            :value="articleContent"
+            @updateValue="$emit('editedContent', $event)"
+          />
+        </div>
+        <app-button
+          class="article-post-submit"
+          button-type="submit"
+          round
+          :disabled="!disabled"
+          @click="handleSubmit"
         >
-          {{ category.name }}
-        </option>
-      </app-select>
-      <app-heading :level="2">
-        タイトル・本文
-      </app-heading>
-      <app-input
-        v-validate="'required'"
-        name="title"
-        type="text"
-        placeholder="記事のタイトルを入力してください。"
-        white-bg
-        data-vv-as="記事のタイトル"
-        :error-messages="errors.collect('title')"
-        :value="articleTitle"
-        @updateValue="$emit('editedTitle', $event)"
-      />
-      <app-textarea
-        v-validate="'required'"
-        name="content"
-        placeholder="記事の本文をマークダウン記法で入力してください。"
-        white-bg
-        data-vv-as="記事の本文"
-        :error-messages="errors.collect('content')"
-        :value="articleContent"
-        @updateValue="$emit('editedContent', $event)"
-      />
-      <app-button
-        class="article-post-submit"
-        button-type="submit"
-        round
-        :disabled="!disabled"
-        @click="handleSubmit"
-      >
-        {{ buttonText }}
-      </app-button>
-    </section>
+          {{ buttonText }}
+        </app-button>
+      </section>
 
-    <article class="article-post-preview">
-      <app-markdown-preview
-        :markdown-content="markdownContent"
-      />
-    </article>
+      <article class="article-post-preview">
+        <app-markdown-preview
+          :markdown-content="markdownContent"
+        />
+      </article>
+    </div>
   </div>
 </template>
 

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -82,7 +82,7 @@ import {
   MarkdownPreview,
   Button,
   Select,
-  // Text,
+  Text,
 } from '@Components/atoms';
 
 export default ({
@@ -93,13 +93,13 @@ export default ({
     appMarkdownPreview: MarkdownPreview,
     appButton: Button,
     appSelect: Select,
-    // appText: Text,
+    appText: Text,
   },
   props: {
-    articleId: {
-      type: Number,
-      default: 0,
-    },
+    // articleId: {
+    //   type: Number,
+    //   default: 0,
+    // },
     articleTitle: {
       type: String,
       default: '',
@@ -146,6 +146,7 @@ export default ({
     handleSubmit() {
       if (!this.access.edit) return;
       this.$validator.validate().then((valid) => {
+        console.log('valid(trueならpagesのhandleSubmitがemitされる):', valid);
         if (valid) this.$emit('handleSubmit');
       });
     },
@@ -155,10 +156,16 @@ export default ({
 
 <style lang="postcss" scoped>
 .article-post {
+  &__columns {
   display: flex;
   height: 100%;
+  /* align-items: flex-end; */
+  }
   &-preview {
-    /* width: 50%; */
+    /* width: 30%; */
+  }
+  &-submit {
+    margin-top: 16px;
   }
 }
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -124,7 +124,7 @@ export default ({
       type: Boolean,
       default: false,
     },
-    doneMessage: {
+    errorMessage: {
       type: String,
       default: '',
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -55,6 +55,15 @@
         :value="articleContent"
         @updateValue="$emit('editedContent', $event)"
       />
+      <app-button
+        class="article-post-submit"
+        button-type="submit"
+        round
+        :disabled="!disabled"
+        @click="handleSubmit"
+      >
+        {{ buttonText }}
+      </app-button>
     </section>
 
     <article class="article-post-preview">
@@ -71,7 +80,7 @@ import {
   Input,
   Textarea,
   MarkdownPreview,
-  // Button,
+  Button,
   Select,
   // Text,
 } from '@Components/atoms';
@@ -82,7 +91,7 @@ export default ({
     appInput: Input,
     appTextarea: Textarea,
     appMarkdownPreview: MarkdownPreview,
-    // appButton: Button,
+    appButton: Button,
     appSelect: Select,
     // appText: Text,
   },
@@ -122,6 +131,15 @@ export default ({
     access: {
       type: Object,
       default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.edit) return '作成権限がありません';
+      return this.loading ? '作成中...' : '作成';
+    },
+    disabled() {
+      return this.access.edit && !this.loading;
     },
   },
 });

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -36,4 +36,16 @@
 import {
   Heading, Input, Textarea, MarkdownPreview, Button, Select, Text,
 } from '@Components/atoms';
+
+export default ({
+  components: {
+    appHeading: Heading,
+    appInput: Input,
+    appTextarea: Textarea,
+    appMarkdownPreview: MarkdownPreview,
+    appButton: Button,
+    appSelect: Select,
+    appText: Text,
+  },
+});
 </script>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -43,11 +43,27 @@ export default ({
     appInput: Input,
     appTextarea: Textarea,
     appMarkdownPreview: MarkdownPreview,
-    appButton: Button,
+    // appButton: Button,
     appSelect: Select,
-    appText: Text,
+    // appText: Text,
   },
   props: {
+    articleId: {
+      type: Number,
+      default: 0,
+    },
+    articleTitle: {
+      type: String,
+      default: '',
+    },
+    articleContent: {
+      type: String,
+      default: '',
+    },
+    markdownContent: {
+      type: String,
+      default: '',
+    },
     currentCategoryName: {
       type: String,
       default: '',

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -61,21 +61,28 @@ export default ({
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
+    // カテゴリー選択
+    selectedArticleCategory($event) {
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    },
+    // 新規追加タイトルの入力
     editedTitle($event) {
       this.$store.dispatch('articles/editedTitle', $event.target.value);
       console.log('title:', $event.target.value);
     },
+    // 新規追加コンテントの入力
     editedContent($event) {
       this.$store.dispatch('articles/editedContent', $event.target.value);
       console.log('content:', $event.target.value);
     },
+    // 送信ボタン押した時
     handleSubmit() {
+      console.log('pages: handleSubmit発火しました');
       if (this.loading) return;
-      this.$store.dispatch('articles/postArticle');
-    },
-    selectedArticleCategory($event) {
-      const categoryName = $event.target.value;
-      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+      this.$store.dispatch('articles/postArticle').then(() => {
+        this.$store.dispatch('articles/initPostArticle');
+      });
     },
   },
 });

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,5 +1,7 @@
 <template lang="html">
   <app-articles-post
+    :article-title="articleTitle"
+    :article-content="articleContent"
     :current-category-name="currentCategoryName"
     :category-list="categoryList"
     :markdown-content="markdownContent"
@@ -27,11 +29,6 @@ export default ({
     };
   },
   computed: {
-    // articleId() {
-    //   let { id } = this.$route.params;
-    //   id = parseInt(id, 10);
-    //   return id;
-    // },
     articleTitle() {
       const { title } = this.$store.state.articles.targetArticle;
       return title;

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -2,6 +2,13 @@
   <app-articles-post
     :current-category-name="currentCategoryName"
     :category-list="categoryList"
+    :markdown-content="markdownContent"
+    :loading="loading"
+    :access="access"
+    @selectedArticleCategory="selectedArticleCategory"
+    @editedTitle="editedTitle"
+    @editedContent="editedContent"
+    @handleSubmit="handleSubmit"
   />
 </template>
 

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -80,6 +80,10 @@ export default ({
       if (this.loading) return;
       this.$store.dispatch('articles/postArticle').then(() => {
         this.$store.dispatch('articles/initPostArticle');
+        this.$router.push({
+          path: '/articles',
+          query: { redirect: '/article/post' },
+        });
       });
     },
   },

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -18,5 +18,22 @@ export default ({
       content: '',
     };
   },
+  computed: {
+    articleTitle() {
+      const { title } = this.$store.state.articles.targetArticle;
+      return title;
+    },
+    articleContent() {
+      const { content } = this.$store.state.articles.targetArticle;
+      return content;
+    },
+    markdownContent() {
+      return `# ${this.articleTitle}\n${this.articleContent}`;
+    },
+    currentCategoryName() {
+      const { name } = this.$store.state.articles.targetArticle.category;
+      return name;
+    },
+  },
 });
 </script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -34,6 +34,16 @@ export default ({
       const { name } = this.$store.state.articles.targetArticle.category;
       return name;
     },
+    categoryList() {
+      const { categoryList } = this.$store.state.categories;
+      return categoryList;
+    },
+  },
+  methods: {
+    selectedArticleCategory($event) {
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    },
   },
 });
 </script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -26,6 +26,11 @@ export default ({
     };
   },
   computed: {
+    // articleId() {
+    //   let { id } = this.$route.params;
+    //   id = parseInt(id, 10);
+    //   return id;
+    // },
     articleTitle() {
       const { title } = this.$store.state.articles.targetArticle;
       return title;

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -70,16 +70,13 @@ export default ({
     // 新規追加タイトルの入力
     editedTitle($event) {
       this.$store.dispatch('articles/editedTitle', $event.target.value);
-      console.log('title:', $event.target.value);
     },
     // 新規追加コンテントの入力
     editedContent($event) {
       this.$store.dispatch('articles/editedContent', $event.target.value);
-      console.log('content:', $event.target.value);
     },
     // 送信ボタン押した時
     handleSubmit() {
-      console.log('pages: handleSubmit発火しました');
       if (this.loading) return;
       this.$store.dispatch('articles/postArticle').then(() => {
         this.$store.dispatch('articles/initPostArticle');

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -4,3 +4,12 @@
     :category-list="categoryList"
   />
 </template>
+
+<script>
+import { CategoryPost } from '@Components/molecules'
+
+export default ({
+  components: {
+    appCategoryPost: CategoryPost,
+  },
+});

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -12,4 +12,11 @@ export default ({
   components: {
     appCategoryPost: CategoryPost,
   },
+  data() {
+    return {
+      title: '',
+      content: '',
+    };
+  },
 });
+</script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,5 +1,6 @@
 <template lang="html">
-  <div>
-    ドキュメントの新規作成画面です
-  </div>
+  <app-article-post
+    :current-category-name="currentCategoryName"
+    :category-list="categoryList"
+  />
 </template>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -45,6 +45,8 @@ export default ({
       const { categoryList } = this.$store.state.categories;
       return categoryList;
     },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
     selectedArticleCategory($event) {

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -4,6 +4,7 @@
     :category-list="categoryList"
     :markdown-content="markdownContent"
     :loading="loading"
+    :error-message="errorMessage"
     :access="access"
     @selectedArticleCategory="selectedArticleCategory"
     @editedTitle="editedTitle"
@@ -52,6 +53,9 @@ export default ({
     },
     loading() {
       return this.$store.state.articles.loading;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
     },
     access() {
       return this.$store.getters['auth/access'];

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -56,6 +56,18 @@ export default ({
     this.$store.dispatch('categories/getAllCategories');
   },
   methods: {
+    editedTitle($event) {
+      this.$store.dispatch('articles/editedTitle', $event.target.value);
+      console.log('title:', $event.target.value);
+    },
+    editedContent($event) {
+      this.$store.dispatch('articles/editedContent', $event.target.value);
+      console.log('content:', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('articles/postArticle');
+    },
     selectedArticleCategory($event) {
       const categoryName = $event.target.value;
       this.$store.dispatch('articles/selectedArticleCategory', categoryName);

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -45,6 +45,13 @@ export default ({
       const { categoryList } = this.$store.state.categories;
       return categoryList;
     },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
   created() {
     this.$store.dispatch('categories/getAllCategories');
   },

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,16 +1,16 @@
 <template lang="html">
-  <app-article-post
+  <app-articles-post
     :current-category-name="currentCategoryName"
     :category-list="categoryList"
   />
 </template>
 
 <script>
-import { CategoryPost } from '@Components/molecules'
+import { ArticlePost } from '@Components/molecules';
 
 export default ({
   components: {
-    appCategoryPost: CategoryPost,
+    appArticlesPost: ArticlePost,
   },
   data() {
     return {


### PR DESCRIPTION
[確認事項]
1. /articles/postにドキュメント新規作成画面が表示されていること
2. 2カラムレイアウトとなっており、左カラムにはカテゴリーを選択するプルダウン、記事のタイトル、マークダウン 形式で本文を入力するテキストエリアがあること、右カラムにはマークダウン本文がhtmlとしてコンパイルして表示されているプレビュー画面が表示されていること
3. カテゴリーを選択するプルダウンの初期表示が「---」となっており(選択不可)、プルダウンを押下すると他の選択肢として登録されているカテゴリー一覧が表示されていること
4. 記事のタイトルが入力必須、記事の本文が入力必須、プルダウンから選択するカテゴリーに対して選択必須のバリデーションの指定がされていること
5. 「作成」ボタン押下時は3の「入力必須項目」に対してバリデーションが適用されていること
6. 「作成」ボタン押下時はAPI通信が完了するまでボタンが非活性状態となっていること
7. APIに対して通信が失敗したときにエラーメッセージが表示されていること
8. APIに対して通信が成功したときは記事一覧にリダイレクトして、記事一覧でドキュメントを作成したメッセージが表示されていること
9. マークダウンのコンパイルに使用しているmarked.jsにスクリプトタグのサニタイズが追加されていること

ご確認のほど、何卒よろしくお願いいたします。