### PR TITLE
GIZUMO_wiki　タスク２　カテゴリー更新機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -99,6 +99,7 @@ export default {
         commit('toggleLoading');
         commit('doneUpdate', newCategory);
       }).catch((err) => {
+        commit('toggleLoading');
         commit('failFetchCategory', { message: err.message });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -14,6 +14,9 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
+    loading: state => state.loading,
+    errorMessage: state => state.errorMessage,
+    doneMessage: state => state.doneMessage,
     updateCategoryName: state => state.updateCategoryName,
     updateCategoryId: state => state.updateCategoryId,
   },
@@ -78,8 +81,8 @@ export default {
         method: 'GET',
         url: `/category/${categoryId}`,
       }).then(({ data }) => {
-        const category = data.category;
-        commit('doneGetCategoryDetail', category);
+        const { id, name } = data.category;
+        commit('doneGetCategoryDetail', { id, name });
       }).catch((err) => {
         commit('failFetchCategory', { message: err.message });
       });
@@ -94,7 +97,7 @@ export default {
       data.append('id', rootGetters['categories/updateCategoryId']);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${this.state.categories.updateCategoryId}`,
+        url: `/category/${rootGetters['categories/updateCategoryId']}`,
         data,
       }).then(({ data }) => {
         const newCategory = data.category;
@@ -111,9 +114,9 @@ export default {
       state.errorMessage = '';
       state.doneMessage = '';
     },
-    doneGetCategoryDetail(state, category) {
-      state.updateCategoryName = category.name;
-      state.updateCategoryId = category.id;
+    doneGetCategoryDetail(state, { id, name }) {
+      state.updateCategoryName = name;
+      state.updateCategoryId = id;
     },
     doneUpdate(state, newCategory) {
       state.updateCategoryId = newCategory.id;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -90,15 +90,15 @@ export default {
     updateValue({ commit }, categoryName) {
       commit('updateValue', { categoryName });
     },
-    updateCategory({ commit, rootGetters }) {
+    updateCategory({ commit, rootGetters, getters }) {
       commit('toggleLoading');
-      const data = new URLSearchParams();
-      data.append('name', rootGetters['categories/updateCategoryName']);
-      data.append('id', rootGetters['categories/updateCategoryId']);
+      const categoryData = new URLSearchParams();
+      categoryData.append('name', getters.updateCategoryName);
+      categoryData.append('id', getters.updateCategoryId);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${rootGetters['categories/updateCategoryId']}`,
-        data,
+        url: `/category/${getters.updateCategoryId}`,
+        data: categoryData,
       }).then(({ data }) => {
         const { id, name } = data.category;
         commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -14,6 +14,8 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
+    updateCategoryName: state => state.updateCategoryName,
+    updateCategoryId: state => state.updateCategoryId,
   },
   actions: {
     clearMessage({ commit }) {
@@ -75,8 +77,8 @@ export default {
       axios(rootGetters['auth/token'])({
         method: 'GET',
         url: `/category/${categoryId}`,
-      }).then((response) => {
-        const category = response.data.category;
+      }).then(({ data }) => {
+        const category = data.category;
         commit('doneGetCategoryDetail', category);
       }).catch((err) => {
         commit('failFetchCategory', { message: err.message });
@@ -88,14 +90,14 @@ export default {
     updateCategory({ commit, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('name', this.state.categories.updateCategoryName);
-      data.append('id', this.state.categories.updateCategoryId);
+      data.append('name', rootGetters['categories/updateCategoryName']);
+      data.append('id', rootGetters['categories/updateCategoryId']);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
         url: `/category/${this.state.categories.updateCategoryId}`,
         data,
-      }).then((response) => {
-        const newCategory = response.data.category
+      }).then(({ data }) => {
+        const newCategory = data.category;
         commit('toggleLoading');
         commit('doneUpdate', newCategory);
       }).catch((err) => {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -100,9 +100,9 @@ export default {
         url: `/category/${rootGetters['categories/updateCategoryId']}`,
         data,
       }).then(({ data }) => {
-        const newCategory = data.category;
+        const { id, name } = data.category;
         commit('toggleLoading');
-        commit('doneUpdate', newCategory);
+        commit('doneUpdate', { id, name });
       }).catch((err) => {
         commit('toggleLoading');
         commit('failFetchCategory', { message: err.message });
@@ -118,9 +118,9 @@ export default {
       state.updateCategoryName = name;
       state.updateCategoryId = id;
     },
-    doneUpdate(state, newCategory) {
-      state.updateCategoryId = newCategory.id;
-      state.updateCategoryName = newCategory.name;
+    doneUpdate(state, { id, name }) {
+      state.updateCategoryId = id;
+      state.updateCategoryName = name;
       state.doneMessage = '更新が成功しました。';
     },
     updateValue(state, { categoryName }) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -71,11 +71,54 @@ export default {
         });
       });
     },
+    getCategory({ commit, rootGetters }, categoryId) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${categoryId}`,
+      }).then((response) => {
+        const category = response.data.category;
+        commit('doneGetCategoryDetail', category);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
+    },
+    updateValue({ commit }, categoryName) {
+      commit('updateValue', { categoryName });
+    },
+    updateCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', this.state.categories.updateCategoryName);
+      data.append('id', this.state.categories.updateCategoryId);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${this.state.categories.updateCategoryId}`,
+        data,
+      }).then((response) => {
+        const newCategory = response.data.category
+        commit('toggleLoading');
+        commit('doneUpdate', newCategory);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
       state.errorMessage = '';
       state.doneMessage = '';
+    },
+    doneGetCategoryDetail(state, category) {
+      state.updateCategoryName = category.name;
+      state.updateCategoryId = category.id;
+    },
+    doneUpdate(state, newCategory) {
+      state.updateCategoryId = newCategory.id;
+      state.updateCategoryName = newCategory.name;
+      state.doneMessage = '更新が成功しました。';
+    },
+    updateValue(state, { categoryName }) {
+      state.updateCategoryName = categoryName;
     },
     doneGetAllCategories(state, { categories }) {
       state.categoryList = [...categories];

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -9,14 +9,19 @@
       hover-opacity
       to="/categories"
     >
+    <!-- RouterLinkはaタグになる -->
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
+      :value="updateCategoryName"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -27,12 +32,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -58,6 +63,18 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    updateCategoryName: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {
@@ -70,7 +87,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -21,7 +21,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('updateCategory')"
       :value="updateCategoryName"
-      @updateValue="$emit('updateValues', $event)"
+      @updateValue="$emit('updateNewValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -85,7 +85,7 @@ export default {
   methods: {
     handleSubmit() {
       if (!this.access.edit) return;
-      this.$emit('clearMessages');
+      this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -20,7 +20,7 @@
       placeholder="カテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('updateCategory')"
-      :value="updateCategoryNames"
+      :value="updateCategoryName"
       @updateValue="$emit('updateValues', $event)"
     />
     <app-button
@@ -32,12 +32,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div v-if="errorMessages" class="category-management-edit__notice">
-      <app-text bg-error>{{ errorMessages }}</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div v-if="doneMessages" class="category-management-edit__notice">
-      <app-text bg-success>{{ doneMessages }}</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -63,15 +63,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    errorMessages: {
+    errorMessage: {
       type: String,
       default: '',
     },
-    doneMessages: {
+    doneMessage: {
       type: String,
       default: '',
     },
-    updateCategoryNames: {
+    updateCategoryName: {
       type: String,
       default: '',
     },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -20,7 +20,7 @@
       placeholder="カテゴリー名を入力してください"
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('updateCategory')"
-      :value="updateCategoryName"
+      :value="updateCategoryNames"
       @updateValue="$emit('updateValue', $event)"
     />
     <app-button
@@ -71,7 +71,7 @@ export default {
       type: String,
       default: '',
     },
-    updateCategoryName: {
+    updateCategoryNames: {
       type: String,
       default: '',
     },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -21,7 +21,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('updateCategory')"
       :value="updateCategoryNames"
-      @updateValue="$emit('updateValue', $event)"
+      @updateValue="$emit('updateValues', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -32,12 +32,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div v-if="errorMessage" class="category-management-edit__notice">
-      <app-text bg-error>{{ errorMessage }}</app-text>
+    <div v-if="errorMessages" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessages }}</app-text>
     </div>
 
-    <div v-if="doneMessage" class="category-management-edit__notice">
-      <app-text bg-success>{{ doneMessage }}</app-text>
+    <div v-if="doneMessages" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessages }}</app-text>
     </div>
   </form>
 </template>
@@ -63,11 +63,11 @@ export default {
       type: Object,
       default: () => ({}),
     },
-    errorMessage: {
+    errorMessages: {
       type: String,
       default: '',
     },
-    doneMessage: {
+    doneMessages: {
       type: String,
       default: '',
     },
@@ -85,7 +85,7 @@ export default {
   methods: {
     handleSubmit() {
       if (!this.access.edit) return;
-      this.$emit('clearMessage');
+      this.$emit('clearMessages');
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -14,6 +14,7 @@
         </tr>
       </thead>
       <transition-group name="fade" tag="tbody" class="category-list__table__body">
+        <!-- リストをアニメーションさせたい時に使う -->
         <tr v-for="category in categories" :key="category.id">
           <td>
             <app-text tag="span">
@@ -158,9 +159,12 @@ export default {
       .fade-enter-active, .fade-leave-active {
         transition: opacity .5s;
       }
+      /* enterがdataを受け取る時、leaveがdata消去した時 */
       .fade-enter, .fade-leave-to {
         opacity: 0;
       }
+      /* 開始がfade-enterでactiveが終了の値になる。この場合opacityが０から１に.5秒かかって遷移する。 */
+      /* labveでdataがなくなる際は、.5秒かけてopacityが０になる */
     }
   }
 }

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -3,7 +3,12 @@
     <app-category-edit
       :disabled="loading ? true : false"
       :access="access"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :update-category-name="updateCategoryName"
       @clearMessage="clearMessage"
+      @handleSubmit="updateCategory"
+      @updateValue="updateValue"
     />
   </div>
 </template>
@@ -15,6 +20,8 @@ export default {
   components: {
     appCategoryEdit: CategoryEdit,
   },
+  // createdでVueインスタンスが読み込まれた時にしたい記述を書く。
+  // mountedだとエレメントが出来てからになり、画面が書き出された後になるため
   computed: {
     access() {
       return this.$store.getters['auth/access'];
@@ -22,10 +29,31 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    updateCategoryName() {
+      return this.$store.state.categories.updateCategoryName;
+    },
+  },
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategory', id);
+    this.$store.dispatch('caterories/clearMessage');
   },
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    updateValue($event) {
+      this.$store.dispatch('categories/updateValue', $event.target.value);
+    },
+    updateCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <app-category-edit
-      :disabled="loading ? true : false"
+      :disabled="loadings ? true : false"
       :access="access"
-      :error-message="errorMessage"
-      :done-message="doneMessage"
+      :error-messages="errorMessages"
+      :done-messages="doneMessages"
       :update-category-names="updateCategoryNames"
-      @clearMessage="clearMessage"
-      @handleSubmit="updateCategory"
-      @updateValue="updateValue"
+      @clearMessages="clearMessages"
+      @handleSubmit="updateCategorys"
+      @updateValues="updateValues"
     />
   </div>
 </template>
@@ -25,19 +25,22 @@ export default {
   // mountedだとエレメントが出来てからになり、画面が書き出された後になるため
   computed: {
     ...mapGetters('categories', [
+      'loading',
+      'errorMessage',
+      'doneMessage',
       'updateCategoryName',
     ]),
     access() {
       return this.$store.getters['auth/access'];
     },
-    loading() {
-      return this.$store.state.categories.loading;
+    loadings() {
+      return this.loading;
     },
-    errorMessage() {
-      return this.$store.state.categories.errorMessage;
+    errorMessages() {
+      return this.errorMessage;
     },
-    doneMessage() {
-      return this.$store.state.categories.doneMessage;
+    doneMessages() {
+      return this.doneMessage;
     },
     updateCategoryNames() {
       return this.updateCategoryName;
@@ -46,21 +49,24 @@ export default {
   created() {
     const { id } = this.$route.params;
     this.getCategory(id);
-    this.$store.dispatch('caterories/clearMessage');
+    this.clearMessage();
   },
   methods: {
     ...mapActions('categories', [
       'getCategory',
+      'clearMessage',
+      'updateValue',
+      'updateCategory'
     ]),
-    clearMessage() {
-      this.$store.dispatch('categories/clearMessage');
+    clearMessages() {
+      this.clearMessage();
     },
-    updateValue($event) {
-      this.$store.dispatch('categories/updateValue', $event.target.value);
+    updateValues($event) {
+      this.updateValue($event.target.value);
     },
-    updateCategory() {
-      if (this.loading) return;
-      this.$store.dispatch('categories/updateCategory');
+    updateCategorys() {
+      if (this.loadings) return;
+      this.updateCategory();
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -6,9 +6,9 @@
       :error-message="errorMessage"
       :done-message="doneMessage"
       :update-category-name="updateCategoryName"
-      @clearMessages="clearMessages"
-      @handleSubmit="updateCategorys"
-      @updateValues="updateValues"
+      @clearMessage="clearMessage"
+      @handleSubmit="updateNewCategory"
+      @updateNewValue="updateNewValue"
     />
   </div>
 </template>
@@ -46,13 +46,10 @@ export default {
       'updateValue',
       'updateCategory',
     ]),
-    clearMessages() {
-      this.clearMessage();
-    },
-    updateValues($event) {
+    updateNewValue($event) {
       this.updateValue($event.target.value);
     },
-    updateCategorys() {
+    updateNewCategory() {
       if (this.loading) return;
       this.updateCategory();
     },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -56,7 +56,7 @@ export default {
       'getCategory',
       'clearMessage',
       'updateValue',
-      'updateCategory'
+      'updateCategory',
     ]),
     clearMessages() {
       this.clearMessage();

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <app-category-edit
-      :disabled="loadings ? true : false"
+      :disabled="loading ? true : false"
       :access="access"
-      :error-messages="errorMessages"
-      :done-messages="doneMessages"
-      :update-category-names="updateCategoryNames"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
+      :update-category-name="updateCategoryName"
       @clearMessages="clearMessages"
       @handleSubmit="updateCategorys"
       @updateValues="updateValues"
@@ -33,18 +33,6 @@ export default {
     access() {
       return this.$store.getters['auth/access'];
     },
-    loadings() {
-      return this.loading;
-    },
-    errorMessages() {
-      return this.errorMessage;
-    },
-    doneMessages() {
-      return this.doneMessage;
-    },
-    updateCategoryNames() {
-      return this.updateCategoryName;
-    },
   },
   created() {
     const { id } = this.$route.params;
@@ -65,7 +53,7 @@ export default {
       this.updateValue($event.target.value);
     },
     updateCategorys() {
-      if (this.loadings) return;
+      if (this.loading) return;
       this.updateCategory();
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -5,7 +5,7 @@
       :access="access"
       :error-message="errorMessage"
       :done-message="doneMessage"
-      :update-category-name="updateCategoryName"
+      :update-category-names="updateCategoryNames"
       @clearMessage="clearMessage"
       @handleSubmit="updateCategory"
       @updateValue="updateValue"
@@ -15,6 +15,7 @@
 
 <script>
 import { CategoryEdit } from '@Components/molecules';
+import { mapGetters, mapActions } from 'vuex';
 
 export default {
   components: {
@@ -23,6 +24,9 @@ export default {
   // createdでVueインスタンスが読み込まれた時にしたい記述を書く。
   // mountedだとエレメントが出来てからになり、画面が書き出された後になるため
   computed: {
+    ...mapGetters('categories', [
+      'updateCategoryName',
+    ]),
     access() {
       return this.$store.getters['auth/access'];
     },
@@ -35,16 +39,19 @@ export default {
     doneMessage() {
       return this.$store.state.categories.doneMessage;
     },
-    updateCategoryName() {
-      return this.$store.state.categories.updateCategoryName;
+    updateCategoryNames() {
+      return this.updateCategoryName;
     },
   },
   created() {
     const { id } = this.$route.params;
-    this.$store.dispatch('categories/getCategory', id);
+    this.getCategory(id);
     this.$store.dispatch('caterories/clearMessage');
   },
   methods: {
+    ...mapActions('categories', [
+      'getCategory',
+    ]),
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },


### PR DESCRIPTION
### **変更内容**

①カテゴリー更新機能を追加しました。
②エラーメッセージと完了メッセージが表示される機能を追加しました。
③Vee-validateでインプットエリア内が空文字の際はエラーが表示される処理を追加しました。

### **変更結果**
カテゴリー更新ボタンを押した際に該当するカテゴリー名をinputエリア内に表示することができ、
カテゴリー名を変更し、更新ボタンを押した際にはAPI通信でカテゴリー内容を更新することができました。
さらにエラー文がある際には動的に切り替わるといった処理も記述しました。

### **修正箇所**
・分割代入を使用し、無駄な記述を減らしました。
・gettersに新たに値を追加し、その値をaction内で使用し、意図しないdataの書き換えを防ぐ記述をしました。
・mapGettersとmapActionsを使用し、コンポーネントからgettersとactionsを参照できる記述をしました。

### **修正箇所　＃２**
・mapGettersやmapActionを使って記述できるところが多々あり、その箇所を前述の記述に書き換えました。
・分割代入で記述できる箇所があったので、そこを分割代入を使い記述しました。
・stateから直接値を取り出していた箇所をgetterを使用して値を取り出す記述に変更しました。