### PR TITLE
カテゴリーの新規作成機能を実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -56,7 +56,7 @@ export default {
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('name', categoryName);
-      return new Promise((resolve,reject) => {
+      return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -69,7 +69,7 @@ export default {
           commit('toggleLoading');
           commit('failFetchCategory', { message: err.message });
           reject();
-        })
+        });
       });
     },
     getCategoryDetail({ commit, rootGetters }, categoryId) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -56,7 +56,7 @@ export default {
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('name', categoryName);
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve,reject) => {
         axios(rootGetters['auth/token'])({
           method: 'POST',
           url: '/category',
@@ -69,7 +69,7 @@ export default {
           commit('toggleLoading');
           commit('failFetchCategory', { message: err.message });
           reject();
-        });
+        })
       });
     },
     getCategoryDetail({ commit, rootGetters }, categoryId) {

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -52,6 +52,26 @@ export default {
         });
       });
     },
+    postCategory({ commit, rootGetters }, categoryName) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', categoryName);
+      return new Promise((resolve,reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          commit('donePostCategory');
+          resolve();
+        }).catch((err) => {
+          commit('toggleLoading');
+          commit('failFetchCategory', { message: err.message });
+          reject();
+        })
+      });
+    },
     getCategoryDetail({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -107,6 +127,9 @@ export default {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
       state.doneMessage = 'カテゴリーの削除が完了しました。';
+    },
+    donePostCategory(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
     doneGetCategoryDetail(state, payload) {
       state.updateCategoryId = payload.id;

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -90,12 +90,12 @@ export default {
     },
     postCategory() {
       if (this.loading) return;
-      this.$store.dispatch('categories/postCategory',this.category)
+      this.$store.dispatch('categories/postCategory', this.category)
         .then(() => {
           this.category = '';
           this.$store.dispatch('categories/getAllCategories');
-        })
-    }
+        });
+    },
   },
 };
 </script>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="postCategory"
       />
     </section>
     <section class="category-management-list">
@@ -87,6 +88,14 @@ export default {
         });
       this.toggleModal();
     },
+    postCategory() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory',this.category)
+        .then(() => {
+          this.category = '';
+          this.$store.dispatch('categories/getAllCategories');
+        })
+    }
   },
 };
 </script>


### PR DESCRIPTION
## 変更内容

- 「作成」ボタンを押した時に、インプットタグ内の入力されている内容を登録。
     - カテゴリー作成に成功した時、「カテゴリーの追加が完了しました。」とメッセージを表示。
     - カテゴリー作成した後、カテゴリー一覧の表示を更新。

- 作成ボタンを押した時は、API通信を完了するまでに非活性にする。 
