### PR TITLE
GIZUMO_wiki (タスク2)　カテゴリー更新機能の実装 

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,6 +19,9 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    editedCategory({ commit }, categoryName) {
+      commit('editedCategoryName', categoryName);
+    },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -35,6 +38,30 @@ export default {
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
+    getCategory({ commit, rootGetters }, updateCategoryId) {
+      const categories = rootGetters['categories/categoryList'];
+      const category = categories.find(item => item.id === updateCategoryId);
+      const { id: categoryId, name: categoryName } = category;
+      commit('doneGetCategory', { categoryId, categoryName });
+    },
+    updateCategory({ commit, state, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('id', state.updateCategoryId);
+      data.append('name', state.updateCategoryName);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${state.updateCategoryId}`,
+        data,
+      }).then((res) => {
+        commit('toggleLoading');
+        const { id: categoryId, name: categoryName } = res.data.category;
+        commit('doneUpdateCategory', { categoryId, categoryName });
+      }).catch((err) => {
+        commit('toggleLoading');
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     postCategory({ commit, rootGetters }, categoryName) {
       return new Promise((resolve, reject) => {
@@ -91,8 +118,20 @@ export default {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
     },
+    editedCategoryName(state, categoryName) {
+      state.updateCategoryName = categoryName;
+    },
+    doneGetCategory(state, { categoryId, categoryName }) {
+      state.updateCategoryId = categoryId;
+      state.updateCategoryName = categoryName;
+    },
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
+    doneUpdateCategory(state, { categoryId, categoryName }) {
+      state.updateCategoryId = categoryId;
+      state.updateCategoryName = categoryName;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -14,6 +14,8 @@ export default {
   },
   getters: {
     categoryList: state => state.categoryList,
+    updateCategoryId: state => state.updateCategoryId,
+    updateCategoryName: state => state.updateCategoryName,
   },
   actions: {
     clearMessage({ commit }) {
@@ -39,20 +41,19 @@ export default {
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
-    getCategory({ commit, rootGetters }, updateCategoryId) {
-      const categories = rootGetters['categories/categoryList'];
-      const category = categories.find(item => item.id === updateCategoryId);
+    getCategory({ commit, getters }, updateCategoryId) {
+      const category = getters.categoryList.find(item => item.id === updateCategoryId);
       const { id: categoryId, name: categoryName } = category;
       commit('doneGetCategory', { categoryId, categoryName });
     },
-    updateCategory({ commit, state, rootGetters }) {
+    updateCategory({ commit, getters, rootGetters }) {
       commit('toggleLoading');
       const data = new URLSearchParams();
-      data.append('id', state.updateCategoryId);
-      data.append('name', state.updateCategoryName);
+      data.append('id', getters.updateCategoryId);
+      data.append('name', getters.updateCategoryName);
       axios(rootGetters['auth/token'])({
         method: 'PUT',
-        url: `/category/${state.updateCategoryId}`,
+        url: `/category/${getters.updateCategoryId}`,
         data,
       }).then((res) => {
         commit('toggleLoading');

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -55,13 +55,12 @@ export default {
         method: 'PUT',
         url: `/category/${getters.updateCategoryId}`,
         data,
-      }).then((res) => {
+      }).then(() => {
         commit('toggleLoading');
-        const { id: categoryId, name: categoryName } = res.data.category;
-        commit('doneUpdateCategory', { categoryId, categoryName });
-      }).catch((err) => {
+        commit('doneUpdateCategory');
+      }).catch(({ message }) => {
         commit('toggleLoading');
-        commit('failFetchCategory', { message: err.message });
+        commit('failFetchCategory', { message });
       });
     },
     postCategory({ commit, rootGetters }, categoryName) {
@@ -129,9 +128,7 @@ export default {
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
-    doneUpdateCategory(state, { categoryId, categoryName }) {
-      state.updateCategoryId = categoryId;
-      state.updateCategoryName = categoryName;
+    doneUpdateCategory(state) {
       state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
     doneDeleteCategory(state) {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,11 +12,15 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
+      :value="categoryName"
+      @updateValue="$emit('editedCategory', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -27,12 +31,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -58,6 +62,18 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    categoryName: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {
@@ -70,7 +86,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -3,7 +3,12 @@
     <app-category-edit
       :disabled="loading ? true : false"
       :access="access"
+      :category-name="categoryName"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
       @clearMessage="clearMessage"
+      @editedCategory="editedCategory"
+      @handleSubmit="handleSubmit"
     />
   </div>
 </template>
@@ -22,10 +27,35 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    categoryId() {
+      let { id } = this.$route.params;
+      id = parseInt(id, 10);
+      return id;
+    },
+    categoryName() {
+      const categoryName = this.$store.state.categories.updateCategoryName;
+      return categoryName;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getCategory', this.categoryId);
   },
   methods: {
+    editedCategory($event) {
+      this.$store.dispatch('categories/editedCategory', $event.target.value);
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };


### PR DESCRIPTION
**変更内容**

①カテゴリー更新機能を実装しました。
②更新ページへのアクセス時、初期表示としてinputタグに更新対象のテキストを表示しました。
③更新ボタン押下後、エラーメッセージまたは完了メッセージが表示される様にしました。
④Vee-validateでインプットエリア内が空文字の際はエラーが表示される処理を追加しました。

**確認事項**

1. 更新ページへのアクセス時、inputタグに更新対象のテキストが表示されているか。
2. vee-valideteプラグインを使用し、 inputタグにテキスト入力が必須のバリデーションが指定されてるか。
3. 2のバリデーションエラー発生時、vee-valideteプラグインを使用しバリデーションエラー文言が表示されてるか。
4. api通信を行い更新の成功時、src/js/components/molecules/CategoryEdit/index.vue内の「ここに更新成功時のメッセージが入ります」の文言をを適切な文言に変えて表示されるか。
5. api通信を行い更新の失敗時、「ここにエラー時のメッセージが入ります」の文言をを適切な文言に変えて表示されるか。

**修正1回目**

・actions内で不必要な、rootGettersやstateを参照せず、gettersを参照する様に修正しました。
・getters参照に伴い、gettersに新たに値を追加しました。

**修正2回目**

・エラー時の値を受け取るcatchメソッドの引数で分割代入を使用しました。
・API通信成功後のthen(( res ))の引数resを削除し、それに伴い引数resを使用するコードを削除しました。

ご確認のほど、何卒よろしくお願いいたします。