### PR TITLE
gizumo wiki [タスク3] 　カテゴリー一覧の機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -21,9 +21,19 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    getAllCategories({ commit }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+    getAllCategories({ commit, rootGetters }) {
+      commit('toggleLoading');
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(({ data }) => {
+        commit('toggleLoading');
+        const { categories } = data;
+        commit('doneGetAllCategories', { categories });
+      }).catch(({ message }) => {
+        commit('toggleLoading');
+        commit('failFetchCategory', { message });
+      });
     },
     editedCategory({ commit }, categoryName) {
       commit('editedCategoryName', categoryName);

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -118,6 +118,10 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
+    doneGetCategory(state, { categoryId, categoryName }) {
+      state.updateCategoryId = categoryId;
+      state.updateCategoryName = categoryName;
+    },
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -84,18 +84,18 @@ export default {
       });
     },
     deleteCategory({ commit, rootGetters }, categoryId) {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         axios(rootGetters['auth/token'])({
           method: 'DELETE',
           url: `/category/${categoryId}`,
-        }).then((response) => {
+        }).then(({ data }) => {
           // NOTE: エラー時はresponse.data.codeが0で返ってくる。
-          if (response.data.code === 0) throw new Error(response.data.message);
-
+          if (data.code === 0) throw new Error(data.message);
           commit('doneDeleteCategory');
           resolve();
-        }).catch((err) => {
-          commit('failFetchCategory', { message: err.message });
+        }).catch(({ message }) => {
+          commit('failFetchCategory', { message });
+          reject();
         });
       });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -38,8 +38,8 @@ export default {
     editedCategory({ commit }, categoryName) {
       commit('editedCategoryName', categoryName);
     },
-    confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
-      commit('confirmDeleteCategory', { categoryId, categoryName });
+    setDeleteCategory({ commit }, { categoryId, categoryName }) {
+      commit('setDeleteCategory', { categoryId, categoryName });
     },
     getCategory({ commit, getters }, updateCategoryId) {
       const category = getters.categoryList.find(item => item.id === updateCategoryId);
@@ -110,6 +110,10 @@ export default {
     },
     failFetchCategory(state, { message }) {
       state.errorMessage = message;
+    },
+    setDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
     toggleLoading(state) {
       state.loading = !state.loading;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -118,6 +118,9 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
+    editedCategoryName(state, categoryName) {
+      state.updateCategoryName = categoryName;
+    },
     doneGetCategory(state, { categoryId, categoryName }) {
       state.updateCategoryId = categoryId;
       state.updateCategoryName = categoryName;

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -111,6 +111,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    deleteCategoryId: {
+      type: Number,
+      default: null,
+    },
     deleteCategoryName: {
       type: String,
       default: '',
@@ -123,7 +127,7 @@ export default {
     },
     handleClick() {
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('deleteCategory');
     },
   },
 };

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -25,6 +25,7 @@
               underline
               small
               hover-opacity
+              :to="{ path: '/articles', query: { category: category.name } }"
             >
               このカテゴリーの記事
             </app-router-link>
@@ -34,6 +35,7 @@
               theme-color
               underline
               hover-opacity
+              :to="`/categories/${category.id}`"
             >
               更新
             </app-router-link>
@@ -44,7 +46,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(category.id, category.name)"
             >
               削除
             </app-button>
@@ -66,7 +68,7 @@
           theme-color
           tag="p"
         >
-          ここに削除するカテゴリー名が入ります
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -109,11 +111,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    deleteCategoryName: {
+      type: String,
+      default: '',
+    },
   },
   methods: {
-    openModal() {
+    openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
       if (!this.access.delete) return;

--- a/src/js/pages/Articles/List.vue
+++ b/src/js/pages/Articles/List.vue
@@ -21,7 +21,7 @@ export default {
     appArticleList: ArticleList,
   },
   mixins: [Mixins],
-  beforeRouteUpdate(to, from, next) {
+  beforeRouteUpdate(to, next) {
     const categoryName = to.query.category ? to.query.category : null;
     this.fetchArticles(categoryName);
     next();

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -19,6 +19,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @deleteCategory="deleteCategory"
       />
     </section>
   </div>
@@ -82,8 +83,9 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
     },
-    openModal() {
+    openModal(categoryId, categoryName) {
       this.toggleModal();
+      this.$store.dispatch('categories/setDeleteCategory', { categoryId, categoryName });
       this.$store.dispatch('categories/clearMessage');
     },
   },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -17,6 +17,7 @@
         :theads="theads"
         :categories="categoryList"
         :delete-category-name="deleteCategoryName"
+        :delete-category-id="deleteCategoryId"
         :access="access"
         @openModal="openModal"
         @deleteCategory="deleteCategory"
@@ -72,12 +73,21 @@ export default {
     updateValue($event) {
       this[$event.target.name] = $event.target.value;
     },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.toggleModal();
+          this.$store.dispatch('categories/getAllCategories');
+        }).catch(() => {
+          this.toggleModal();
+        });
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('categories/postCateogry', this.category)
+      this.$store.dispatch('categories/postCategory', this.category)
         .then(() => {
           this.category = '';
           this.$store.dispatch('categories/getAllCategories');


### PR DESCRIPTION
**変更内容**

1. カテゴリー一覧表示機能を作成しました。
2. カテゴリー削除機能を作成しました。
3. 「このカテゴリーの記事」のリンクを押下後、そのカテゴリーに紐づく記事一覧に遷移する実装をしました。
4. 「更新」ボタン押下後、そのカテゴリーの詳細・編集画面に遷移する実装をしました。
5. 「削除」ボタン押下後、削除モーダルを表示し、削除対象のカテゴリー名をモーダルに表示する実装をしました。

**確認事項**

1. 表示する画面のURLは/categories
2. カテゴリー一覧ページへアクセス後、バックエンドにリクエストを投げてカテゴリー一覧を取得できているか。
3. 「カテゴリー名」のテーブルに取得したカテゴリーの一覧が表示されてるか。
4. 「このカテゴリーの記事」のリンクを押下後、そのカテゴリーに紐づく記事一覧に遷移するか。(遷移先は「/articles?category=カテゴリー名」
5. 「更新」ボタン押下後、そのカテゴリーの詳細・編集画面に遷移するか。(遷移先は「/categories/カテゴリーid」)
6. 「削除」 ボタン押下後、削除モーダルが表示されるか。モーダルに削除対象のカテゴリー名が表示されているか。
7. 削除モーダルの「削除する」ボタンを押下後、6で表示されている削除対象のカテゴリーが削除されるか。その後、モーダルを閉じ削除された状態のカテゴリー一覧が表示されるか。

ご確認のほど、何卒よろしくお願いいたします。