### PR TITLE
gizumo wiki [タスク4] 　ドキュメント新規作成機能の実装  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,6 +4432,11 @@
         "color-name": "^1.0.0"
       }
     },
+    "colorette": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+    },
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
@@ -5225,6 +5230,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
       "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -7398,7 +7408,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7416,11 +7427,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7433,15 +7446,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7544,7 +7560,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7554,6 +7571,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7566,17 +7584,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7593,6 +7614,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7665,7 +7687,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7675,6 +7698,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7750,7 +7774,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7780,6 +7805,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7797,6 +7823,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7835,11 +7862,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9928,6 +9957,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
     "lazy": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
@@ -10687,6 +10721,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11544,6 +11583,11 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "4.0.0",
@@ -13800,6 +13844,91 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -14375,6 +14504,11 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "marked": "^0.7.0",
     "morgan": "^1.9.1",
     "pm2": "^3.5.0",
+    "sanitize-html": "^2.4.0",
     "vee-validate": "^2.2.7",
     "vue": "^2.6.6",
     "vue-router": "^3.0.3",

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -63,6 +63,7 @@ export default {
         highlight: (code, lang) => hljs.highlightAuto(code, [lang]).value,
         breaks: false,
         smartLists: true,
+        sanitize: true,
       });
       return marked(this.markdownContent);
     },

--- a/src/js/components/atoms/MarkdownPreview/index.vue
+++ b/src/js/components/atoms/MarkdownPreview/index.vue
@@ -10,6 +10,7 @@
 <script>
 import marked from 'marked';
 import hljs from 'highlight.js';
+import sanitizeHtml from 'sanitize-html';
 
 export default {
   props: {
@@ -63,9 +64,9 @@ export default {
         highlight: (code, lang) => hljs.highlightAuto(code, [lang]).value,
         breaks: false,
         smartLists: true,
-        sanitize: true,
       });
-      return marked(this.markdownContent);
+      const markedContent = marked(this.markdownContent);
+      return sanitizeHtml(markedContent);
     },
   },
   mounted() {

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -16,6 +16,7 @@
           v-validate="'required'"
           name="category"
           data-vv-as="カテゴリー"
+          :value="currentCategoryName"
           :error-messages="errors.collect('category')"
           @updateValue="$emit('selectedArticleCategory', $event)"
         >
@@ -86,6 +87,76 @@
   </div>
 </template>
 
+<script>
+import {
+  Heading, MarkdownPreview, Textarea, Input, Button, Select, Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appTextarea: Textarea,
+    appMarkdownPreview: MarkdownPreview,
+    appInput: Input,
+    appButton: Button,
+    appSelect: Select,
+    appText: Text,
+  },
+  props: {
+    articleTitle: {
+      type: String,
+      default: '',
+    },
+    articleContent: {
+      type: String,
+      default: '',
+    },
+    markdownContent: {
+      type: String,
+      default: '',
+    },
+    currentCategoryName: {
+      type: String,
+      default: '',
+    },
+    categoryList: {
+      type: Array,
+      default: () => [],
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '作成権限がありません';
+      return this.loading ? '投稿中...' : '作成';
+    },
+    disabled() {
+      return this.access.create && !this.loading;
+    },
+  },
+  methods: {
+    handleSubmit() {
+      if (!this.access.create) return;
+      this.$validator.validate().then((valid) => {
+        console.log('valid:', valid);
+        if (valid) this.$emit('handleSubmit');
+      });
+    },
+  },
+};
+</script>
+
 <style lang="postcss" scoped>
 .article-post {
   &__columns {
@@ -117,4 +188,3 @@
   }
 }
 </style>
-

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -86,3 +86,35 @@
   </div>
 </template>
 
+<style lang="postcss" scoped>
+.article-post {
+  &__columns {
+    display: flex;
+    height: 100%;
+  }
+  &-editor {
+    padding-right: 2%;
+    width: 50%;
+    border-right: 1px solid #ccc;
+    &-title {
+      margin-top: 16px;
+    }
+  }
+  &-preview {
+    margin-left: 2%;
+    width: 48%;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+  &-form {
+    margin-top: 20px;
+  }
+  &-submit {
+    margin-top: 16px;
+  }
+  &__notice--update {
+    margin-bottom: 16px;
+  }
+}
+</style>
+

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,10 +1,7 @@
 <template lang="html">
   <div class="article-post">
-    <div v-if="errorMessage" class="category-management-edit__notice">
+    <div v-if="errorMessage" class="article-post__notice--update">
       <app-text bg-error>{{ errorMessage }}</app-text>
-    </div>
-    <div v-if="doneMessage" class="article-post__notice--update">
-      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
     <div class="article-post__columns">
       <section class="article-post-editor">
@@ -134,10 +131,6 @@ export default {
       type: String,
       default: '',
     },
-    doneMessage: {
-      type: String,
-      default: '',
-    },
     access: {
       type: Object,
       default: () => ({}),
@@ -156,7 +149,6 @@ export default {
     handleSubmit() {
       if (!this.access.create) return;
       this.$validator.validate().then((valid) => {
-        console.log('valid:', valid);
         if (valid) this.$emit('handleSubmit');
       });
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,5 +1,8 @@
 <template lang="html">
   <div class="article-post">
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
+    </div>
     <div v-if="doneMessage" class="article-post__notice--update">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
@@ -126,6 +129,10 @@ export default {
     loading: {
       type: Boolean,
       default: false,
+    },
+    errorMessage: {
+      type: String,
+      default: '',
     },
     doneMessage: {
       type: String,

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,0 +1,88 @@
+<template lang="html">
+  <div class="article-post">
+    <div v-if="doneMessage" class="article-post__notice--update">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <div class="article-post__columns">
+      <section class="article-post-editor">
+        <app-heading :level="1">記事の新規作成</app-heading>
+        <app-heading
+          class="article-post-editor-title"
+          :level="2"
+        >
+          カテゴリーの選択
+        </app-heading>
+        <app-select
+          v-validate="'required'"
+          name="category"
+          data-vv-as="カテゴリー"
+          :error-messages="errors.collect('category')"
+          @updateValue="$emit('selectedArticleCategory', $event)"
+        >
+          <option
+            value=""
+            selected
+            disabled
+          >
+            ---
+          </option>
+          <option
+            v-for="(category) in categoryList"
+            :key="category.id"
+            :value="category.name"
+          >
+            {{ category.name }}
+          </option>
+        </app-select>
+        <app-heading
+          class="article-post-editor-title"
+          :level="2"
+        >
+          タイトル・本文
+        </app-heading>
+        <div class="article-post-form">
+          <app-input
+            v-validate="'required'"
+            name="title"
+            type="text"
+            placeholder="記事のタイトルを入力してください。"
+            white-bg
+            data-vv-as="記事のタイトル"
+            :error-messages="errors.collect('title')"
+            :value="articleTitle"
+            @updateValue="$emit('editedTitle', $event)"
+          />
+        </div>
+
+        <div class="article-post-form">
+          <app-textarea
+            v-validate="'required'"
+            name="content"
+            placeholder="記事の本文をマークダウン記法で入力してください。"
+            white-bg
+            data-vv-as="記事の本文"
+            :error-messages="errors.collect('content')"
+            :value="articleContent"
+            @updateValue="$emit('editedContent', $event)"
+          />
+        </div>
+        <app-button
+          class="article-post-submit"
+          button-type="submit"
+          round
+          :disabled="!disabled"
+          @click="handleSubmit"
+        >
+          {{ buttonText }}
+        </app-button>
+      </section>
+
+      <article class="article-post-preview">
+        <app-markdown-preview
+          :markdown-content="markdownContent"
+        />
+      </article>
+    </div>
+  </div>
+</template>
+

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -5,7 +5,6 @@
     :loading="loading"
     :access="access"
     :error-message="errorMessage"
-    :done-message="doneMessage"
     :current-category-name="currentCategoryName"
     :article-title="articleTitle"
     :article-content="articleContent"
@@ -68,7 +67,12 @@ export default {
     },
     handleSubmit() {
       if (this.loading) return;
-      this.$store.dispatch('articles/postArticle');
+      this.$store.dispatch('articles/postArticle').then(() => {
+        this.$router.push({
+          path: '/articles',
+          query: { redirect: this.$route.fullPath },
+        });
+      });
     },
     selectedArticleCategory($event) {
       const categoryName = $event.target.value;

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -7,5 +7,3 @@
     @selectedArticleCategory="selectedArticleCategory"
   />
 </template>
-
-

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,5 +1,11 @@
 <template lang="html">
-  <div>
-    ドキュメントの新規作成画面です
-  </div>
+  <app-article-post
+    :category-list="categoryList"
+    :markdown-content="markdownContent"
+    :loading="loading"
+    :access="access"
+    @selectedArticleCategory="selectedArticleCategory"
+  />
 </template>
+
+

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -4,6 +4,7 @@
     :markdown-content="markdownContent"
     :loading="loading"
     :access="access"
+    :error-message="errorMessage"
     :done-message="doneMessage"
     :current-category-name="currentCategoryName"
     :article-title="articleTitle"
@@ -50,6 +51,9 @@ export default {
     },
     doneMessage() {
       return this.$store.state.articles.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
     },
   },
   created() {

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -4,6 +4,72 @@
     :markdown-content="markdownContent"
     :loading="loading"
     :access="access"
+    :done-message="doneMessage"
+    :current-category-name="currentCategoryName"
+    :article-title="articleTitle"
+    :article-content="articleContent"
     @selectedArticleCategory="selectedArticleCategory"
+    @editedTitle="editedTitle"
+    @editedContent="editedContent"
+    @handleSubmit="handleSubmit"
   />
 </template>
+
+<script>
+import { ArticlePost } from '@Components/molecules';
+
+export default {
+  components: {
+    appArticlePost: ArticlePost,
+  },
+  computed: {
+    articleTitle() {
+      const { title } = this.$store.state.articles.targetArticle;
+      return title;
+    },
+    articleContent() {
+      const { content } = this.$store.state.articles.targetArticle;
+      return content;
+    },
+    currentCategoryName() {
+      const { name } = this.$store.state.articles.targetArticle.category;
+      return name;
+    },
+    categoryList() {
+      const { categoryList } = this.$store.state.categories;
+      return categoryList;
+    },
+    markdownContent() {
+      return `# ${this.articleTitle}\n${this.articleContent}`;
+    },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    editedContent($event) {
+      this.$store.dispatch('articles/editedContent', $event.target.value);
+    },
+    editedTitle($event) {
+      this.$store.dispatch('articles/editedTitle', $event.target.value);
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('articles/postArticle');
+    },
+    selectedArticleCategory($event) {
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
**変更内容**

・「articles/post」のURLへ遷移後、仕様のキャプチャ画像が表示される様、html,css部分の実装を行いました。
・記事のタイトル、記事の本文、カテゴリーを入力し作成ボタン押下後、ドキュメント新規作成される様、実装しました。

**確認事項**

1. 表示する画面のURLは/articles/post
2. 2カラムレイアウトとし、左カラムにはカテゴリーを選択するプルダウン、記事のタイトル、マークダウン 形式で本文を入力するテキストエリアがあること。右カラムには、入力したタイトル、マークダウン本文がhtmlとしてコンパイルされているプレビュー画面が表示されること。
3. カテゴリーを選択するプルダウンは初期表示は「---」となっており（選択不可）、プルダウンを選択すると登録するカテゴリーから選択することができるか。
4. 記事のタイトル、記事の本文、プルダウンから登録するカテゴリーは入力必須か。
5. 「作成」ボタン押下後、「入力必須項目に対して」バリデーションが適用されるか(バリデーションにはvee-validateを使用)
6. 「作成」ボタン押下後、API通信が完了するまでボタンが非活性にされてるか。
7. API通信失敗時、エラーメッセージが表示されるか。
8. 「通信」成功時は、記事一覧へリダイレクトし記事一覧でドキュメントを作成したメッセージが表示されるか。
9. マークダウンに関して、スクリプトタグのサニタイズ処理が追加されているか。

**修正項目**

1.サニタイズを「sanitize-html」ライブラリを使って処理する様変更しました。

ご確認のほど、何卒よろしくお願いいたします。