### PR TITLE
カテゴリー更新機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -33,6 +33,12 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    getCategoryInput({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      })
+    },
     updateCategory({ commit }, { editCategoryName, editCategoryId }) {
       commit('updateCategory', { editCategoryName, editCategoryId });
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -33,6 +33,9 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    updateCategory({ commit }, { editCategoryName, editCategoryId }) {
+      commit('updateCategory', { editCategoryName, editCategoryId });
+    },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });
     },
@@ -72,6 +75,10 @@ export default {
         });
       });
     },
+    editCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      console.log('参上')
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -86,6 +93,10 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    updateCategory(state, { editCategoryName, editCategoryId }) {
+      state.updateCategoryName = editCategoryName;
+      state.updateCategoryId = editCategoryId;
     },
     confirmDeleteCategory(state, { categoryId, categoryName }) {
       state.deleteCategoryId = categoryId;

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -20,7 +20,7 @@
       data-vv-as="カテゴリー名"
       :error-messages="errors.collect('updateCategory')"
       :value="editCategoryName"
-      @updateValue="$emit('updateValue', $event)"
+      @updateValue="$emit('updateValueParent', $event)"
     />
     <app-button
       class="category-management-edit__submit"

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -16,7 +16,9 @@
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー"
+      :value="editCategoryName"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -27,12 +29,12 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -58,6 +60,18 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    editCategoryName: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     buttonText() {
@@ -70,7 +84,7 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -12,11 +12,13 @@
       カテゴリー一覧へ戻る
     </app-router-link>
     <app-input
+      v-validate="'required'"
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as="カテゴリー"
+      data-vv-as="カテゴリー名"
+      :error-messages="errors.collect('updateCategory')"
       :value="editCategoryName"
       @updateValue="$emit('updateValue', $event)"
     />

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -3,7 +3,12 @@
     <app-category-edit
       :disabled="loading ? true : false"
       :access="access"
+      :edit-category-name="editCategoryName"
+      :error-message="errorMessage"
+      :done-message="doneMessage"
       @clearMessage="clearMessage"
+      @handleSubmit="handleSubmit"
+      @updateValue="updateValue"
     />
   </div>
 </template>
@@ -12,6 +17,10 @@
 import { CategoryEdit } from '@Components/molecules';
 
 export default {
+  data: {
+    editCategoryName: '',
+    editCategoryId: null,
+  },
   components: {
     appCategoryEdit: CategoryEdit,
   },
@@ -22,10 +31,25 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    editCategoryName() {
+      return this.$store.state.categories.updateCategoryName;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
   },
   methods: {
+    updateValue($event) {
+      this.$store.dispatch('categories/updateCategory', $event.target.value);
+    },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/editCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -8,7 +8,7 @@
       :done-message="doneMessage"
       @clearMessage="clearMessage"
       @handleSubmit="updateCategory"
-      @updateValue="updateValue"
+      @updateValueParent="updateValue"
     />
   </div>
 </template>
@@ -17,12 +17,6 @@
 import { CategoryEdit } from '@Components/molecules';
 
 export default {
-  data() {
-    return {
-      editCategoryName: '',
-      editCategoryId: null,
-    }
-  },
   components: {
     appCategoryEdit: CategoryEdit,
   },
@@ -43,20 +37,21 @@ export default {
       return this.$store.state.categories.doneMessage;
     },
   },
-  create() {
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryInput', id);
     this.$store.dispatch('categories/clearMessage');
-    this.$store.dispatch('categories/editCategoryInput', this.editCategoryId);
   },
   methods: {
     updateValue($event) {
-      this.$store.dispatch('categories/updateCategory', $event.target.value);
+      this.$store.dispatch('categories/editCategoryName', $event.target.value);
     },
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
     updateCategory() {
-      if (!this.loading) return;
-      this.$store.dispatch('categories/editCategory');
+      if (this.loading) return;
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -7,7 +7,7 @@
       :error-message="errorMessage"
       :done-message="doneMessage"
       @clearMessage="clearMessage"
-      @handleSubmit="handleSubmit"
+      @handleSubmit="updateCategory"
       @updateValue="updateValue"
     />
   </div>
@@ -17,9 +17,11 @@
 import { CategoryEdit } from '@Components/molecules';
 
 export default {
-  data: {
-    editCategoryName: '',
-    editCategoryId: null,
+  data() {
+    return {
+      editCategoryName: '',
+      editCategoryId: null,
+    }
   },
   components: {
     appCategoryEdit: CategoryEdit,
@@ -41,6 +43,10 @@ export default {
       return this.$store.state.categories.doneMessage;
     },
   },
+  create() {
+    this.$store.dispatch('categories/clearMessage');
+    this.$store.dispatch('categories/editCategoryInput', this.editCategoryId);
+  },
   methods: {
     updateValue($event) {
       this.$store.dispatch('categories/updateCategory', $event.target.value);
@@ -48,7 +54,8 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    handleSubmit() {
+    updateCategory() {
+      if (!this.loading) return;
       this.$store.dispatch('categories/editCategory');
     },
   },


### PR DESCRIPTION
Gizumo Wiki タスク２のカテゴリー更新機能の実装

## 変更内容
- 更新したいカテゴリーに対してルーティングした時に、inputタグに該当のテキストを表示。
- 更新ボタンを押した時に、非同期通信を行うためボタンを非活性化「更新 ⇨ 更新中...」
   - 非同期通信時にエラーが発生した場合は該当のエラーメッセージの表示。
- 更新が完了した際は、非活性ボタンを元に戻す。「更新中... ⇨ 更新」
   - また、更新完了時に「カテゴリーの更新が完了しました。」の完了メッセージを表示する。 
- 最後にカテゴリー一覧へ戻ると、更新したカテゴリーが反映される。

## 確認項目
- ページにアクセス時、初期表示として inputタグに更新対象のテキスト表示ができているか。
- api通信を行い更新に成功した時は、適切な完了メッセージの文言が表示されているか。
- api通信を行い更新に失敗した時、適切なエラーメッセージの文言が表示されているか。
- vee-valideteを使用したinputタグに入力必須のバリデーションエラーの表示がされているか。