### PR TITLE
カテゴリー一覧機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,9 +19,16 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    getAllCategories({ commit }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category`
+      }).then((response) => {
+        const payload = { categories: response.data.categories };
+        commit('doneGetAllCategories', payload);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     getCategoryInput({ commit, rootGetters }, categoryId) {
       axios(rootGetters['auth/token'])({

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -42,6 +42,9 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    editCategoryName({ commit }, categoryValue ) {
+      commit('updateCategoryName', { categoryValue });
+    },
     deleteCategory({ commit, rootGetters }, categoryId) {
       return new Promise((resolve) => {
         axios(rootGetters['auth/token'])({
@@ -117,6 +120,13 @@ export default {
       state.deleteCategoryId = categoryId;
       state.deleteCategoryName = categoryName;
     },
+    doneGetCategoryInput(state, { categoryId, categoryName }) {
+      state.updateCategoryId = categoryId;
+      state.updateCategoryName = categoryName;
+    },
+    updateCategoryName(state, { categoryValue }) {
+      state.updateCategoryName = categoryValue;
+    },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';
@@ -124,6 +134,9 @@ export default {
     },
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
+    },
+    doneUpdateCategory(state) {
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -58,6 +58,9 @@ export default {
         });
       });
     },
+    deleteCategoryName({ commit }, { categoryId, categoryName }) {
+      commit('confirmDeleteCategory', { categoryId, categoryName });
+    },
     postCategory({ commit, rootGetters }, categoryName) {
       commit('toggleLoading');
       const data = new URLSearchParams();
@@ -109,6 +112,10 @@ export default {
     },
     toggleLoading(state) {
       state.loading = !state.loading;
+    },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
     },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -22,7 +22,7 @@
           </td>
           <td>
             <app-router-link
-              :to="`/categories/${category.id}`"
+              :to="`/articles?category=${category.name}`"
               underline
               small
               hover-opacity

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -44,7 +44,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(category.id, category.name)"
             >
               削除
             </app-button>
@@ -66,7 +66,7 @@
           theme-color
           tag="p"
         >
-          ここに削除するカテゴリー名が入ります
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -105,19 +105,23 @@ export default {
         return [];
       },
     },
+    deleteCategoryName: {
+      type: String,
+      default: "",
+    },
     access: {
       type: Object,
       default: () => ({}),
     },
   },
   methods: {
-    openModal() {
+    openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('handleDelete');
     },
   },
 };

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -22,6 +22,7 @@
           </td>
           <td>
             <app-router-link
+              :to="`/categories/${category.id}`"
               underline
               small
               hover-opacity
@@ -31,6 +32,7 @@
           </td>
           <td>
             <app-router-link
+              :to="`/categories/${category.id}`"
               theme-color
               underline
               hover-opacity

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -19,6 +19,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @handleDelete="deleteCategory"
       />
     </section>
   </div>
@@ -74,9 +75,10 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    openModal() {
+    openModal(categoryId, categoryName) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/deleteCategoryName',{ categoryId, categoryName});
     },
     postCategory() {
       if (this.loading) return;
@@ -86,6 +88,13 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
     },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+      .then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+      this.toggleModal();
+    }
   },
 };
 </script>


### PR DESCRIPTION
Gizumo Wiki タスク３のカテゴリー一覧の実装
## 変更内容
- カテゴリーページにアクセスした時、カテゴリー一覧の表示。
- カテゴリーの詳細、更新の遷移先の実装。
- 削除ボタンをクリックした時、削除モーダルの表示。また削除を押した時、該当のカテゴリーが削除されたカテゴリー一覧の表示。
- カテゴリー編集画面で、inputタグのテキスト表示と更新ボタン機能の実装。

## 確認内容
- urlは/categoriesであるか。
- カテゴリーページに遷移した時、カテゴリー一覧の取得・表示。
- 「このカテゴリーの記事」のリンクで、カテゴリーに紐付く記事一覧に遷移。
   - 遷移先は「/articles?category=カテゴリー名」へ。
- 「更新」ボタンで、カテゴリーの詳細・編集画面に遷移。
   - 遷移先は「/categories/カテゴリーid」へ。
- 「削除」ボタンで、削除モーダルの表示。またモーダルの「ここに削除するカテゴリー名が入ります」の箇所に削除対象のカテゴリー名を表示する。
- 削除モーダルの削除ボタンをクリックしたら、カテゴリーが削除されその後モーダルを閉じ、新たにカテゴリー一覧を表示させる。  