### PR TITLE
ドキュメント新規作成の機能実装

### DIFF
--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,6 +1,63 @@
 <template lang="html">
   <div class="article-post">
-    
+    <div v-if="doneMessage">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <div>
+      <section>
+        <app-heading :level="1">記事の新規作成</app-heading>
+        <app-heading :level="2">カテゴリーの選択</app-heading>
+        <app-select
+          v-validate="'required'"
+          name="category"
+          data-vv-as="カテゴリー"
+          :value="selectedCategoryName"
+          :error-messages="errors.collect('category')"
+          @updateValue="$emit('selectedCategory', $event)"
+        >
+          <option
+            value=""
+            selected
+            disabled
+          >
+            ---
+          </option>
+          <option
+            v-for="category in categoryList"
+            :key="category.id"
+            :value="category.name"
+          >
+            {{ category.name }}
+          </option>
+        </app-select>
+        <div v-if="errorMessages">
+          <app-text bg-error>{{ errorMessage }}</app-text>
+        </div>
+        <app-heading :level="2">タイトル・本文</app-heading>
+        <app-input
+          v-validate="'required'"
+          name="title"
+          type="text"
+          placeholder="記事のタイトルを入力してください。"
+          data-vv-as="タイトル"
+          :error-messages="errors.collect('title')"
+        />
+        <div v-if="errorMessages">
+          <app-text bg-error>{{ errorMessage }}</app-text>
+        </div>
+        <app-textarea
+          placeholder="記事の本文をマークダウン記法で入力してください。"
+        />
+        <app-button
+          round
+        >
+          作成
+        </app-button>
+        <article>
+          <app-markdown-preview />
+        </article>
+      </section>
+    </div>
   </div>
 </template>
 
@@ -12,26 +69,43 @@ import {
   MarkdownPreview,
   Button,
   Select,
-  Text
-} from '@Components/atoms'
+  Text,
+} from '@Components/atoms';
 
 export default {
   components: {
-    heading: Heading,
-    input: Input,
-    textarea: Textarea,
-    markdownPreview: MarkdownPreview,
-    button: Button,
-    Select: Select,
-    text: Text,
+    appHeading: Heading,
+    appInput: Input,
+    appTextarea: Textarea,
+    appMarkdownPreview: MarkdownPreview,
+    appButton: Button,
+    appSelect: Select,
+    appText: Text,
   },
-  props :{
-
-  }
-
-}
+  props: {
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',
+    },
+    selectedCategoryName: {
+      type: String,
+      default: '',
+    },
+    categoryList: {
+      type: Array,
+      default: () => [],
+    },
+  },
+};
 </script>
 
-<style>
+<style lang="postcss" scoped>
+.article-post {
+  /* display: flex; */
+}
 
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -30,9 +30,6 @@
             {{ category.name }}
           </option>
         </app-select>
-        <div v-if="errorMessages">
-          <app-text bg-error>{{ errorMessage }}</app-text>
-        </div>
         <app-heading :level="2">タイトル・本文</app-heading>
         <app-input
           v-validate="'required'"
@@ -44,9 +41,6 @@
           :value="articleTitle"
           @updateValue="$emit('titleArticle', $event)"
         />
-        <div v-if="errorMessages">
-          <app-text bg-error>{{ errorMessage }}</app-text>
-        </div>
         <app-textarea
           v-validate="'required'"
           name="content"
@@ -59,16 +53,17 @@
         <app-button
           round
           type="button"
+          :disabled="!disabled"
           @click="handleSubmit"
         >
-          作成
+          {{ buttonText }}
         </app-button>
       </section>
-        <article>
-          <app-markdown-preview
-            :markdown-content="markdownContent"
-          />
-        </article>
+      <article>
+        <app-markdown-preview
+          :markdown-content="markdownContent"
+        />
+      </article>
     </div>
   </div>
 </template>
@@ -126,16 +121,24 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
-    }
+    },
+  },
+  computed: {
+    buttonText() {
+      if (!this.access.create) return '作成権限がありません。';
+      return this.loading ? '作成中...' : '作成';
+    },
+    disabled() {
+      return this.access.create && !this.loading;
+    },
   },
   methods: {
     handleSubmit() {
-      if(!this.access.create) return;
-      this.$emit('clearMessage');
+      if (!this.access.create) return;
       this.$validator.validate().then((valid) => {
         if (valid) this.$emit('handleSubmit');
       });
-    }
+    },
   },
 };
 </script>
@@ -144,5 +147,4 @@ export default {
 .article-post {
   display: flex;
 }
-
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,9 +1,9 @@
 <template lang="html">
-  <div class="article-post">
+  <div>
     <div v-if="doneMessage">
       <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
-    <div>
+    <div class="article-post">
       <section>
         <app-heading :level="1">記事の新規作成</app-heading>
         <app-heading :level="2">カテゴリーの選択</app-heading>
@@ -41,22 +41,32 @@
           placeholder="記事のタイトルを入力してください。"
           data-vv-as="タイトル"
           :error-messages="errors.collect('title')"
+          :value="articleTitle"
+          @updateValue="$emit('titleArticle', $event)"
         />
         <div v-if="errorMessages">
           <app-text bg-error>{{ errorMessage }}</app-text>
         </div>
         <app-textarea
+          v-validate="'required'"
+          name="content"
           placeholder="記事の本文をマークダウン記法で入力してください。"
+          data-vv-as="記事の本文"
+          :error-messages="errors.collect('content')"
+          :value="articleContent"
+          @updateValue="$emit('contentArticle', $event)"
         />
         <app-button
           round
         >
           作成
         </app-button>
-        <article>
-          <app-markdown-preview />
-        </article>
       </section>
+        <article>
+          <app-markdown-preview
+            :markdown-content="markdownContent"
+          />
+        </article>
     </div>
   </div>
 </template>
@@ -83,6 +93,10 @@ export default {
     appText: Text,
   },
   props: {
+    title: {
+      type: String,
+      default: '',
+    },
     doneMessage: {
       type: String,
       default: '',
@@ -99,13 +113,25 @@ export default {
       type: Array,
       default: () => [],
     },
+    articleTitle: {
+      type: String,
+      default: '',
+    },
+    articleContent: {
+      type: String,
+      default: '',
+    },
+    markdownContent: {
+      type: String,
+      default: '',
+    },
   },
 };
 </script>
 
 <style lang="postcss" scoped>
 .article-post {
-  /* display: flex; */
+  display: flex;
 }
 
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,12 +1,17 @@
 <template lang="html">
-  <div>
+  <div class="article-post">
     <div v-if="errorMessage">
       <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
-    <div class="article-post">
-      <section>
+    <div class="article-post__columns">
+      <section class="article-post-editor">
         <app-heading :level="1">記事の新規作成</app-heading>
-        <app-heading :level="2">カテゴリーの選択</app-heading>
+        <app-heading
+          :level="2"
+          class="article-post-editor-title"
+        >
+        カテゴリーの選択
+        </app-heading>
         <app-select
           v-validate="'required'"
           name="category"
@@ -30,27 +35,37 @@
             {{ category.name }}
           </option>
         </app-select>
-        <app-heading :level="2">タイトル・本文</app-heading>
-        <app-input
-          v-validate="'required'"
-          name="title"
-          type="text"
-          placeholder="記事のタイトルを入力してください。"
-          data-vv-as="タイトル"
-          :error-messages="errors.collect('title')"
-          :value="articleTitle"
-          @updateValue="$emit('titleArticle', $event)"
-        />
-        <app-textarea
-          v-validate="'required'"
-          name="content"
-          placeholder="記事の本文をマークダウン記法で入力してください。"
-          data-vv-as="記事の本文"
-          :error-messages="errors.collect('content')"
-          :value="articleContent"
-          @updateValue="$emit('contentArticle', $event)"
-        />
+        <app-heading
+          :level="2"
+          class="article-post-editor-title"
+        >
+        タイトル・本文
+        </app-heading>
+        <div class="article-post-form">
+          <app-input
+            v-validate="'required'"
+            name="title"
+            type="text"
+            placeholder="記事のタイトルを入力してください。"
+            data-vv-as="タイトル"
+            :error-messages="errors.collect('title')"
+            :value="articleTitle"
+            @updateValue="$emit('titleArticle', $event)"
+          />
+        </div>
+        <div class="article-post-form">
+          <app-textarea
+            v-validate="'required'"
+            name="content"
+            placeholder="記事の本文をマークダウン記法で入力してください。"
+            data-vv-as="記事の本文"
+            :error-messages="errors.collect('content')"
+            :value="articleContent"
+            @updateValue="$emit('contentArticle', $event)"
+          />
+        </div>
         <app-button
+          class="article-post-submit"
           round
           type="button"
           :disabled="!disabled"
@@ -59,7 +74,7 @@
           {{ buttonText }}
         </app-button>
       </section>
-      <article>
+      <article class="article-post-preview">
         <app-markdown-preview
           :markdown-content="markdownContent"
         />
@@ -145,6 +160,32 @@ export default {
 
 <style lang="postcss" scoped>
 .article-post {
-  display: flex;
+  &__columns {
+    display: flex;
+    height: 100%;
+  }
+  &-editor {
+    padding-right: 2%;
+    width: 50%;
+    border-right: 1px solid #ccc;
+    &-title {
+      margin-top: 16px;
+    }
+  }
+  &-preview {
+    margin-left: 2%;
+    width: 48%;
+    overflow-y: scroll;
+    background-color: #fff;
+  }
+  &-form {
+    margin-top: 20px;
+  }
+  &-submit {
+    margin-top: 16px;
+  }
+  &__notice--update {
+    margin-bottom: 16px;
+  }
 }
 </style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -10,7 +10,7 @@
           :level="2"
           class="article-post-editor-title"
         >
-        カテゴリーの選択
+          カテゴリーの選択
         </app-heading>
         <app-select
           v-validate="'required'"
@@ -39,7 +39,7 @@
           :level="2"
           class="article-post-editor-title"
         >
-        タイトル・本文
+          タイトル・本文
         </app-heading>
         <div class="article-post-form">
           <app-input
@@ -105,10 +105,6 @@ export default {
     appText: Text,
   },
   props: {
-    title: {
-      type: String,
-      default: '',
-    },
     errorMessage: {
       type: String,
       default: '',

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,0 +1,37 @@
+<template lang="html">
+  <div class="article-post">
+    
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  Input,
+  Textarea,
+  MarkdownPreview,
+  Button,
+  Select,
+  Text
+} from '@Components/atoms'
+
+export default {
+  components: {
+    heading: Heading,
+    input: Input,
+    textarea: Textarea,
+    markdownPreview: MarkdownPreview,
+    button: Button,
+    Select: Select,
+    text: Text,
+  },
+  props :{
+
+  }
+
+}
+</script>
+
+<style>
+
+</style>

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div>
-    <div v-if="doneMessage">
-      <app-text bg-success>{{ doneMessage }}</app-text>
+    <div v-if="errorMessage">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
     <div class="article-post">
       <section>
@@ -96,10 +96,6 @@ export default {
   },
   props: {
     title: {
-      type: String,
-      default: '',
-    },
-    doneMessage: {
       type: String,
       default: '',
     },

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -58,6 +58,8 @@
         />
         <app-button
           round
+          type="button"
+          @click="handleSubmit"
         >
           作成
         </app-button>
@@ -125,6 +127,19 @@ export default {
       type: String,
       default: '',
     },
+    access: {
+      type: Object,
+      default: () => ({}),
+    }
+  },
+  methods: {
+    handleSubmit() {
+      if(!this.access.create) return;
+      this.$emit('clearMessage');
+      this.$validator.validate().then((valid) => {
+        if (valid) this.$emit('handleSubmit');
+      });
+    }
   },
 };
 </script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -9,9 +9,12 @@
       :article-title="articleTitle"
       :article-content="articleContent"
       :markdown-content="markdownContent"
+      :access="access"
       @selectedCategory="selectedCategory"
       @titleArticle="titleArticle"
       @contentArticle="contentArticle"
+      @handleSubmit="handleSubmit"
+      @clearMessage="clearMessage"
     />
   </div>
 </template>
@@ -49,6 +52,12 @@ export default {
     markdownContent() {
       return `# ${this.articleTitle}\n${this.articleContent}`;
     },
+    loading() {
+      return this.$store.state.articles.loading;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -65,6 +74,15 @@ export default {
     contentArticle($event) {
       const value = $event.target.value;
       this.$store.dispatch('articles/editedContent', value);
+    },
+    clearMessage() {
+      this.$store.dispatch('articles/clearMessage');
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('articles/postArticle').then(() => {
+        this.$router.push('/articles');
+      });
     },
   },
 };

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,16 +1,45 @@
 <template lang="html">
   <div>
-    <article-post />
+    <article-post
+      :done-message="doneMessage"
+      :error-message="errorMessage"
+      :selected-category-name="selectedCategoryName"
+      :category-list="categoryList"
+      @selectedCategory="selectedCategory"
+    />
   </div>
 </template>
 <script>
-import { ArticlePost } from '@Components/molecules'
+import { ArticlePost } from '@Components/molecules';
 
 export default {
   components: {
-    articlePost: ArticlePost
+    articlePost: ArticlePost,
   },
-  
-}
+  computed: {
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.articles.errorMessage;
+    },
+    selectedCategoryName() {
+      return this.$store.state.articles.targetArticle.category.name;
+    },
+    categoryList() {
+      return this.$store.state.categories.categoryList;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+  methods: {
+    selectedCategory($event) {
+      const value = $event.target.value;
+      console.log(value);
+      this.$store.dispatch('articles/selectedArticleCategory', value);
+    },
+  },
+};
 
 </script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,11 +1,17 @@
 <template lang="html">
   <div>
     <article-post
+      :title="title"
       :done-message="doneMessage"
       :error-message="errorMessage"
       :selected-category-name="selectedCategoryName"
       :category-list="categoryList"
+      :article-title="articleTitle"
+      :article-content="articleContent"
+      :markdown-content="markdownContent"
       @selectedCategory="selectedCategory"
+      @titleArticle="titleArticle"
+      @contentArticle="contentArticle"
     />
   </div>
 </template>
@@ -15,6 +21,11 @@ import { ArticlePost } from '@Components/molecules';
 export default {
   components: {
     articlePost: ArticlePost,
+  },
+  data() {
+    return {
+      title: '',
+    };
   },
   computed: {
     doneMessage() {
@@ -29,6 +40,15 @@ export default {
     categoryList() {
       return this.$store.state.categories.categoryList;
     },
+    articleTitle() {
+      return this.$store.state.articles.targetArticle.title;
+    },
+    articleContent() {
+      return this.$store.state.articles.targetArticle.content;
+    },
+    markdownContent() {
+      return `# ${this.articleTitle}\n${this.articleContent}`;
+    },
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
@@ -36,8 +56,15 @@ export default {
   methods: {
     selectedCategory($event) {
       const value = $event.target.value;
-      console.log(value);
       this.$store.dispatch('articles/selectedArticleCategory', value);
+    },
+    titleArticle($event) {
+      const value = $event.target.value;
+      this.$store.dispatch('articles/editedTitle', value);
+    },
+    contentArticle($event) {
+      const value = $event.target.value;
+      this.$store.dispatch('articles/editedContent', value);
     },
   },
 };

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,5 +1,16 @@
 <template lang="html">
   <div>
-    ドキュメントの新規作成画面です
+    <article-post />
   </div>
 </template>
+<script>
+import { ArticlePost } from '@Components/molecules'
+
+export default {
+  components: {
+    articlePost: ArticlePost
+  },
+  
+}
+
+</script>

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -13,7 +13,6 @@
       @titleArticle="titleArticle"
       @contentArticle="contentArticle"
       @handleSubmit="handleSubmit"
-      @clearMessage="clearMessage"
     />
   </div>
 </template>
@@ -27,6 +26,7 @@ export default {
   data() {
     return {
       title: '',
+      content: '',
     };
   },
   computed: {
@@ -61,24 +61,24 @@ export default {
   },
   methods: {
     selectedCategory($event) {
-      const value = $event.target.value;
+      const { value } = $event.target.value;
       this.$store.dispatch('articles/selectedArticleCategory', value);
     },
     titleArticle($event) {
-      const value = $event.target.value;
-      this.$store.dispatch('articles/editedTitle', value);
+      const title = $event.target.value;
+      this.$store.dispatch('articles/editedTitle', title);
     },
     contentArticle($event) {
-      const value = $event.target.value;
-      this.$store.dispatch('articles/editedContent', value);
-    },
-    clearMessage() {
-      this.$store.dispatch('articles/clearMessage');
+      const content = $event.target.value;
+      this.$store.dispatch('articles/editedContent', content);
     },
     handleSubmit() {
       if (this.loading) return;
       this.$store.dispatch('articles/postArticle').then(() => {
-        this.$router.push('/articles');
+        this.$router.push({
+          path: '/articles',
+          query: { redirect: '/article/post' },
+        });
       });
     },
   },

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -2,7 +2,6 @@
   <div>
     <article-post
       :title="title"
-      :done-message="doneMessage"
       :error-message="errorMessage"
       :selected-category-name="selectedCategoryName"
       :category-list="categoryList"
@@ -31,9 +30,6 @@ export default {
     };
   },
   computed: {
-    doneMessage() {
-      return this.$store.state.articles.doneMessage;
-    },
     errorMessage() {
       return this.$store.state.articles.errorMessage;
     },
@@ -61,6 +57,7 @@ export default {
   },
   created() {
     this.$store.dispatch('categories/getAllCategories');
+    this.$store.dispatch('articles/initPostArticle');
   },
   methods: {
     selectedCategory($event) {

--- a/src/js/pages/Articles/Post.vue
+++ b/src/js/pages/Articles/Post.vue
@@ -1,13 +1,13 @@
 <template lang="html">
   <div>
     <article-post
-      :title="title"
       :error-message="errorMessage"
       :selected-category-name="selectedCategoryName"
       :category-list="categoryList"
       :article-title="articleTitle"
       :article-content="articleContent"
       :markdown-content="markdownContent"
+      :loading="loading"
       :access="access"
       @selectedCategory="selectedCategory"
       @titleArticle="titleArticle"
@@ -61,8 +61,8 @@ export default {
   },
   methods: {
     selectedCategory($event) {
-      const { value } = $event.target.value;
-      this.$store.dispatch('articles/selectedArticleCategory', value);
+      const categoryName = $event.target.value;
+      this.$store.dispatch('articles/selectedArticleCategory', categoryName);
     },
     titleArticle($event) {
       const title = $event.target.value;


### PR DESCRIPTION
## 変更内容
- 記事一覧の「ドキュメント新規作成」ボタンを押した時の新規作成画面の作成。
   - 右カラムに入力項目
   - 左カラムに入力した内容のプレビュー表示
- 「作成」ボタンが押されAPI通信が成功した時、記事一覧画面へページ遷移。

## 確認事項

1. /articles/post にドキュメント新規作成画面が表示されていること。
2. 2カラムレイアウトの作成。
   - 左カラムにカテゴリー選択, 記事タイトル, マークダウン形式の入力テキストエリア。
   - 右カラムにマークダウン本文がHTMLとしてコンパイルして表示されるプレビュー画面になっているか。
3. カテゴリー選択するプルダウンの初期表示が「---」（選択不可）で、プルダウンを押すと他の選択肢として登録されているカテゴリー一覧が表示されているか。
4. タイトルと本文、選択カテゴリーに対して選択必須のバリデーションの指定がされているか。
5. 「作成」ボタンの非活性化、バリデーションの適用。
6. API通信に対して通信可否に応じたメッセージの表示がされているか。
7. マークダウンのコンパイルに使用しているmarked.jsにスクリプトのサニタイズが追加されていること。