### PR TITLE
Develop kazumaru katou

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,6 +85,7 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }, categoryName) {
+      commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('name', categoryName);
       return new Promise((resolve, reject) => {
@@ -93,9 +94,11 @@ export default {
           url: '/category',
           data,
         }).then(() => {
+          commit('toggleLoading');
           resolve();
         }).catch((err) => {
           commit('failFetchCategory', { message: err.message });
+          commit('toggleLoading');
           reject();
         });
       });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -86,6 +86,7 @@ export default {
     },
     postCategory({ commit, rootGetters }, categoryName) {
       commit('toggleLoading');
+      commit('clearMessage');
       const data = new URLSearchParams();
       data.append('name', categoryName);
       return new Promise((resolve, reject) => {
@@ -95,6 +96,7 @@ export default {
           data,
         }).then(() => {
           commit('toggleLoading');
+          commit('donePostCategory');
           resolve();
         }).catch((err) => {
           commit('failFetchCategory', { message: err.message });
@@ -138,6 +140,9 @@ export default {
       state.updateCategoryId = payload.id;
       state.updateCategoryId = payload.name;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    donePostCategory(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -84,6 +84,22 @@ export default {
         commit('toggleLoading');
       });
     },
+    postCategory({ commit, rootGetters }, categoryName) {
+      const data = new URLSearchParams();
+      data.append('name', categoryName);
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          resolve();
+        }).catch((err) => {
+          commit('failFetchCategory', { message: err.message });
+          reject();
+        });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {

--- a/src/js/components/molecules/CategoryPost/index.vue
+++ b/src/js/components/molecules/CategoryPost/index.vue
@@ -16,6 +16,7 @@
       button-type="submit"
       round
       :disabled="disabled || !access.create"
+      @click="$emit('postCategory')"
     >
       {{ buttonText }}
     </app-button>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @postCategory="postCategory"
       />
     </section>
     <section class="category-management-list">
@@ -86,6 +87,9 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
       this.toggleModal();
+    },
+    postCategory() {
+      this.$store.dispatch('categories/postCategory', this.category);
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -89,7 +89,10 @@ export default {
       this.toggleModal();
     },
     postCategory() {
-      this.$store.dispatch('categories/postCategory', this.category);
+      this.$store.dispatch('categories/postCategory', this.category)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
     },
   },
 };


### PR DESCRIPTION
# カテゴリー新規作成機能の実装
* 内容
    * インプットタグ内に入力されている値をカテゴリー登録apiを使用して登録 する
    * 「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性にする
    * カテゴリーの作成に成功したときは、「カテゴリーの追加が完了しました」というメッセージが表示される
    * カテゴリーの作成に成功したあと、画面右側に表示されているカテゴリー一覧の表示が更新される