### PR TITLE
新規カテゴリー作成機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | サインイン | `/signin` |
 | サインアウト | `/signout` |
 | カテゴリー一覧・追加  | `/categories` |
-| 記事一覧 | `/articles` |
+| 記事一覧 | `/articles` | 
 | 記事詳細 | `/articles/:id` |
 | 更新 | `/articles/:id/edit` |
 | 投稿 | `/articles/post` |

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,9 +19,6 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    // doneMessage({ commit }) {
-    //   commit('doneMassage');
-    // },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -56,7 +53,6 @@ export default {
       });
     },
     postCategory({ commit, rootGetters }, categoryName) {
-      console.log(categoryName);
       commit('toggleLoading');
       const data = new URLSearchParams();
       data.append('name', categoryName);
@@ -67,6 +63,7 @@ export default {
           data,
         }).then(() => {
           commit('toggleLoading');
+          commit('donePostCategory');
           resolve();
         }).catch((err) => {
           commit('failFetchCategory', { message: err.message });
@@ -113,11 +110,11 @@ export default {
       state.errorMessage = '';
       state.doneMessage = '';
     },
-    // doneMessage(state) {
-    //   state.doneMessage = 'カテゴリーの追加が完了しました';
-    // },
     doneGetAllCategories(state, { categories }) {
       state.categoryList = [...categories];
+    },
+    donePostCategory(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
     failFetchCategory(state, { message }) {
       state.errorMessage = message;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,6 +19,9 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
+    // doneMessage({ commit }) {
+    //   commit('doneMassage');
+    // },
     getAllCategories({ commit, rootGetters }) {
       axios(rootGetters['auth/token'])({
         method: 'GET',
@@ -49,6 +52,26 @@ export default {
           resolve();
         }).catch((err) => {
           commit('failFetchCategory', { message: err.message });
+        });
+      });
+    },
+    postCategory({ commit, rootGetters }, categoryName) {
+      console.log(categoryName);
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', categoryName);
+      return new Promise((resolve, reject) => {
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then(() => {
+          commit('toggleLoading');
+          resolve();
+        }).catch((err) => {
+          commit('failFetchCategory', { message: err.message });
+          commit('toggleLoading');
+          reject();
         });
       });
     },
@@ -90,6 +113,9 @@ export default {
       state.errorMessage = '';
       state.doneMessage = '';
     },
+    // doneMessage(state) {
+    //   state.doneMessage = 'カテゴリーの追加が完了しました';
+    // },
     doneGetAllCategories(state, { categories }) {
       state.categoryList = [...categories];
     },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -51,11 +51,11 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
-    doneMessage() {
-      return this.$store.state.categories.doneMessage;
-    },
     categoryList() {
       return this.$store.state.categories.categoryList;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
     },
     deleteCategoryId() {
       return this.$store.state.categories.deleteCategoryId;
@@ -67,7 +67,6 @@ export default {
   created() {
     this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
-    // this.$store.dispatch('categories/doneMessage');
   },
   methods: {
     updateValue($event) {
@@ -76,9 +75,6 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    // doneMessage() {
-    //   this.$store.dispatch('categories/doneMessage');
-    // },
     openModal(categoryId, categoryName) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
@@ -89,6 +85,7 @@ export default {
       if (this.loading) return;
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
+        this.$store.dispatch('categories/getAllCategories');
         this.$router.push({
           path: '/categories',
           query: { redirect: '/category/post' },

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -9,6 +9,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </section>
     <section class="category-management-list">
@@ -66,6 +67,7 @@ export default {
   created() {
     this.$store.dispatch('categories/clearMessage');
     this.$store.dispatch('categories/getAllCategories');
+    // this.$store.dispatch('categories/doneMessage');
   },
   methods: {
     updateValue($event) {
@@ -74,11 +76,24 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
+    // doneMessage() {
+    //   this.$store.dispatch('categories/doneMessage');
+    // },
     openModal(categoryId, categoryName) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
       this.$store.dispatch('categories/confirmDeleteCategory',
         { categoryId, categoryName });
+    },
+    handleSubmit() {
+      if (this.loading) return;
+      this.$store.dispatch('categories/postCategory', this.category).then(() => {
+        this.category = '';
+        this.$router.push({
+          path: '/categories',
+          query: { redirect: '/category/post' },
+        });
+      });
     },
     deleteCategory() {
       this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)


### PR DESCRIPTION
■実装内容
・インプットタグ内に入力されている値をカテゴリー登録apiを使用して登録
・「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性に
・カテゴリーの作成に成功したときは、「カテゴリーの追加が完了しました」というメッセージを表示
・カテゴリーの作成に成功したあと、画面右側に表示されているカテゴリー一覧の表示を更新