### PR TITLE
カテゴリー一覧の機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -124,5 +124,9 @@ export default {
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
+    doneGetCategoryDetail(state, payload) {
+      state.updateCategoryName = payload.name;
+      state.updateCategoryId = payload.id;
+    },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -124,6 +124,10 @@ export default {
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
     doneGetCategoryDetail(state, payload) {
       state.updateCategoryName = payload.name;
       state.updateCategoryId = payload.id;

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,8 +20,18 @@ export default {
       commit('clearMessage');
     },
     getAllCategories({ commit, rootGetters }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then((response) => {
+        const responseData = { categories: [] };
+        response.data.categories.forEach((value) => {
+          responseData.categories.push(value);
+        });
+        commit('doneGetAllCategories', responseData);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -25,6 +25,7 @@
               underline
               small
               hover-opacity
+              :to="`/articles?category=${category.name}`"
             >
               このカテゴリーの記事
             </app-router-link>

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -122,7 +122,7 @@ export default {
     },
     handleClick() {
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('deleteCategory');
     },
   },
 };

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -31,6 +31,7 @@
           </td>
           <td>
             <app-router-link
+            :to="`/categories/${category.id}`"
               theme-color
               underline
               hover-opacity

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -45,7 +45,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(category.id, category.name)"
             >
               削除
             </app-button>
@@ -67,7 +67,7 @@
           theme-color
           tag="p"
         >
-          {{ 'ここに削除するカテゴリー名が入ります' }}
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -110,11 +110,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    deleteCategoryName: {
+      type: String,
+      default: '',
+    },
   },
   methods: {
-    openModal() {
+    openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
       if (!this.access.delete) return;

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -19,6 +19,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @deleteCategory="deleteCategory"
       />
     </section>
   </div>
@@ -82,6 +83,13 @@ export default {
     },
     postCategory() {
       this.$store.dispatch('categories/postCategory', this.category)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+    },
+    deleteCategory() {
+      this.toggleModal();
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
         .then(() => {
           this.$store.dispatch('categories/getAllCategories');
         });

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -74,9 +74,11 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    openModal() {
+    openModal(categoryId, categoryName) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/confirmDeleteCategory',
+        { categoryId, categoryName });
     },
     postCategory() {
       this.$store.dispatch('categories/postCategory', this.category)


### PR DESCRIPTION
## 内容

* ページにアクセスしたときにカテゴリー一覧を取得
* 更新ボタンで、そのカテゴリーの詳細・編集画面に遷移する
* 削除 ボタンで、削除モーダルを表示させ削除対象のカテゴリー名が表示される
* 削除モーダルの「削除する」ボタンをクリックしたら削除対象のカテゴリーが削除され、その後モーダルを閉じ削除された状態のカテゴリー一覧を表示
* このカテゴリーの記事のリンクで、そのカテゴリーに紐づく記事一覧に遷移する