### PR TITLE
カテゴリー一覧の機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -20,8 +20,18 @@ export default {
       commit('clearMessage');
     },
     getAllCategories({ commit, rootGetters }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then((response) => {
+        const payload = { categories: [] };
+        response.data.categories.forEach((val) => {
+          payload.categories.push(val);
+        });
+        commit('doneGetAllCategories', payload);
+      }).catch((err) => {
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     confirmDeleteCategory({ commit }, { categoryId, categoryName }) {
       commit('confirmDeleteCategory', { categoryId, categoryName });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -112,6 +112,10 @@ export default {
     donePostCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました。';
     },
+    doneGetCategoryDetail(state, payload) {
+      state.updateCategoryId = payload.id;
+      state.updateCategoryName = payload.name;
+    },
     failFetchCategory(state, { message }) {
       state.errorMessage = message;
     },

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -122,6 +122,10 @@ export default {
     toggleLoading(state) {
       state.loading = !state.loading;
     },
+    confirmDeleteCategory(state, { categoryId, categoryName }) {
+      state.deleteCategoryId = categoryId;
+      state.deleteCategoryName = categoryName;
+    },
     doneDeleteCategory(state) {
       state.deleteCategoryId = null;
       state.deleteCategoryName = '';

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -25,6 +25,7 @@
               underline
               small
               hover-opacity
+              :to="`/articles?category=${category.name}`"
             >
               このカテゴリーの記事
             </app-router-link>

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -35,6 +35,7 @@
               theme-color
               underline
               hover-opacity
+              :to="`/categories/${category.id}`"
             >
               更新
             </app-router-link>

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -46,7 +46,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(category.id, category.name)"
             >
               削除
             </app-button>
@@ -68,7 +68,7 @@
           theme-color
           tag="p"
         >
-          {{ 'ここに削除するカテゴリー名が入ります' }}
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -111,15 +111,19 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    deleteCategoryName: {
+      type: String,
+      default: '',
+    },
   },
   methods: {
-    openModal() {
+    openModal(categoryId, categoryName) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', categoryId, categoryName);
     },
     handleClick() {
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('handleClick');
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -19,6 +19,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @handleClick="deleteCategory"
       />
     </section>
   </div>
@@ -74,15 +75,24 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    openModal() {
+    openModal(categoryId, categoryName) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/confirmDeleteCategory',
+        { categoryId, categoryName });
     },
     handleSubmit() {
       this.$store.dispatch('categories/postCategory', this.category).then(() => {
         this.category = '';
         this.$store.dispatch('categories/getAllCategories');
       });
+    },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory', this.deleteCategoryId)
+        .then(() => {
+          this.$store.dispatch('categories/getAllCategories');
+        });
+      this.toggleModal();
     },
   },
 };


### PR DESCRIPTION
 # What

- ページにアクセスしたときの初期表示として、カテゴリー一覧APIから取得したデータを基にカテゴリーの一覧を表示
- 「カテゴリー名」のテーブルに取得したカテゴリーの一覧を表示されている
- 「このカテゴリーの記事」のリンクをクリックすると、該当のカテゴリーに属している記事一覧がを表示
- 「更新」ボタンをクリックすると、そのカテゴリーの詳細・編集画面に遷移
- 「削除」 ボタンをクリックして表示されるモーダル内に、削除対象のカテゴリー名を表示
- モーダルの「削除する」ボタンをクリックしたら、6で表示されているカテゴリーが削除され、その後にモーダルが閉じ削除された状態のカテゴリー一覧を表示