### PR TITLE
削除済み記事一覧の追加

### DIFF
--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -16,6 +16,11 @@ export default [
   },
   {
     id: 4,
+    name: '削除済み記事',
+    path: '/articles/trashed',
+  },
+  {
+    id: 5,
     name: 'ユーザー',
     path: '/users',
   },

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -15,6 +15,7 @@ import CategoryEdit from '@Pages/Categories/Edit';
 // 記事
 import Articles from '@Pages/Articles';
 import ArticleList from '@Pages/Articles/List';
+import ArticleTrashedList from '@Pages/Articles/TrashedList';
 import ArticleDetail from '@Pages/Articles/Detail';
 import ArticleEdit from '@Pages/Articles/Edit';
 import ArticlePost from '@Pages/Articles/Post';
@@ -86,7 +87,9 @@ const router = new VueRouter({
              * 記事作成、記事更新、記事削除からリダイレクトするときは?redirect=リダイレクト元のurlのパラメータを
              * 渡してリダイレクト、パラメータが存在する場合はclearMessageアクションを通知しない
              */
-            const isArticle = from.name ? from.name.indexOf('article') >= 0 : false;
+            const isArticle = from.name
+              ? from.name.indexOf('article') >= 0
+              : false;
             const isRedirect = to.query.redirect;
             if (isArticle && isRedirect) {
               next();
@@ -95,6 +98,11 @@ const router = new VueRouter({
               next();
             }
           },
+        },
+        {
+          name: 'articleTrashedList',
+          path: 'trashed',
+          component: ArticleTrashedList,
         },
         {
           name: 'articlePost',

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -164,7 +164,6 @@ export default {
           method: 'GET',
           url: '/article/trashed',
         });
-        console.log(data);
         const payload = {
           trashedArticles: data.articles,
         };

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -44,6 +44,10 @@ export default {
         return count <= 10;
       });
     },
+    sortDateTrashedArticles(state) {
+      const copyArray = [...state.trashedArticleList];
+      return copyArray.sort((prev, next) => (prev.created_at < next.created_at ? 1 : -1));
+    },
     targetArticle: state => state.targetArticle,
     deleteArticleId: state => state.deleteArticleId,
   },
@@ -169,7 +173,7 @@ export default {
         };
         commit('doneGetTrashedArticles', payload);
       } catch (err) {
-        console.log(err);
+        // console.log(err);
       }
     },
     getArticleDetail({ commit, rootGetters }, articleId) {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -164,6 +164,7 @@ export default {
           method: 'GET',
           url: '/article/trashed',
         });
+        console.log(data);
         const payload = {
           trashedArticles: data.articles,
         };

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -304,7 +304,6 @@ export default {
       } catch (err) {
         commit('toggleLoading');
         commit('failRequest', { message: err.message });
-        throw new Error(err);
       }
     },
     clearMessage({ commit }) {

--- a/src/js/_store/modules/articles.js
+++ b/src/js/_store/modules/articles.js
@@ -24,6 +24,7 @@ export default {
       },
     },
     articleList: [],
+    trashedArticleList: [],
     deleteArticleId: null,
     loading: false,
     doneMessage: '',
@@ -80,6 +81,9 @@ export default {
     },
     doneGetArticles(state, payload) {
       state.articleList = [...payload.articles];
+    },
+    doneGetTrashedArticles(state, payload) {
+      state.trashedArticleList = [...payload.trashedArticles];
     },
     editedTitle(state, payload) {
       state.targetArticle = Object.assign(
@@ -153,6 +157,20 @@ export default {
             reject();
           });
       });
+    },
+    async getTrashedArticles({ commit, rootGetters }) {
+      try {
+        const { data } = await axios(rootGetters['auth/token'])({
+          method: 'GET',
+          url: '/article/trashed',
+        });
+        const payload = {
+          trashedArticles: data.articles,
+        };
+        commit('doneGetTrashedArticles', payload);
+      } catch (err) {
+        console.log(err);
+      }
     },
     getArticleDetail({ commit, rootGetters }, articleId) {
       return new Promise((resolve, reject) => {

--- a/src/js/components/atoms/ListItem/index.vue
+++ b/src/js/components/atoms/ListItem/index.vue
@@ -19,6 +19,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    directionColumn: {
+      type: Boolean,
+      default: false,
+    },
     bgWhite: {
       type: Boolean,
       default: false,
@@ -39,6 +43,7 @@ export default {
         'list-item--flex': this.flex,
         'list-item--space-beetween': this.beetween,
         'list-item--align-items': this.alignItems,
+        'list-item--direction-column': this.directionColumn,
         'list-item--bg-white': this.bgWhite,
         'list-item--large': this.large,
         'list-item--border-bottom-gray': this.borderBottomGray,
@@ -64,6 +69,9 @@ export default {
 }
 .list-item--align-items {
   align-items: center;
+}
+.list-item--direction-column {
+  flex-direction: column;
 }
 .list-item--bg-white {
   background-color: var(--white);

--- a/src/js/components/molecules/ArticlePost/index.vue
+++ b/src/js/components/molecules/ArticlePost/index.vue
@@ -6,10 +6,7 @@
     <div class="article-post__columns">
       <section class="article-post-editor">
         <app-heading :level="1">記事の新規作成</app-heading>
-        <app-heading
-          :level="2"
-          class="article-post-editor-title"
-        >
+        <app-heading :level="2" class="article-post-editor-title">
           カテゴリー選択
         </app-heading>
         <app-select
@@ -29,7 +26,12 @@
             {{ category.name }}
           </option>
         </app-select>
-        <app-heading :level="2" class="article-post-editor-title">タイトル・本文</app-heading>
+        <app-heading
+          :level="2"
+          class="article-post-editor-title"
+        >
+          タイトル・本文
+        </app-heading>
         <div class="article-post-form">
           <app-input
             v-validate="'required'"
@@ -96,7 +98,7 @@ export default {
   props: {
     errorMessage: {
       type: String,
-      default: '',
+      required: true,
     },
     disabled: {
       type: Boolean,
@@ -104,27 +106,27 @@ export default {
     },
     targetArray: {
       type: Array,
-      default: () => [],
+      required: true,
     },
     articleTitle: {
       type: String,
-      default: '',
+      required: true,
     },
     articleContent: {
       type: String,
-      default: '',
+      required: true,
     },
     markdownContent: {
       type: String,
-      default: '',
+      required: true,
     },
     currentCategoryName: {
       type: String,
-      default: '',
+      required: true,
     },
     access: {
       type: Object,
-      default: () => {},
+      required: true,
     },
     loading: {
       type: Boolean,

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -1,0 +1,173 @@
+<template lang="html">
+  <div class="article-list">
+    <div v-if="doneMessage" class="article-list__notice--create">
+      <app-text bg-success>{{ doneMessage }}</app-text>
+    </div>
+    <app-heading :level="1">{{ articleTitle }}</app-heading>
+    <app-router-link
+      to="articles/post"
+      key-color
+      white
+      bg-lightgreen
+      small
+      round
+      hover-opacity
+      class="article-list__create-link"
+    >
+      新しいドキュメントを作る
+    </app-router-link>
+    <transition-group
+      class="article-list__articles"
+      name="fade"
+      tag="ul"
+    >
+      <app-list-item
+        v-for="article in targetArray"
+        :key="article.id"
+        flex
+        beetween
+        align-items
+        bg-white
+        large
+        border-bottom-gray
+      >
+        <app-text
+          class="article-list__title"
+        >
+          {{ article.title }}
+        </app-text>
+        <div class="article-list__links">
+          <app-router-link
+            :to="`/articles/${article.id}`"
+            theme-color
+            underline
+            hover-opacity
+          >
+            詳細
+          </app-router-link>
+          <app-router-link
+            :to="`/articles/${article.id}/edit`"
+            white
+            bg-lightgreen
+            small
+            round
+            hover-opacity
+          >
+            更新
+          </app-router-link>
+          <app-button
+            bg-danger
+            small
+            round
+            hover-opacity
+            :disabled="!access.delete"
+            @click="openModal(article.id)"
+          >
+            {{ buttonText }}
+          </app-button>
+        </div>
+      </app-list-item>
+    </transition-group>
+    <app-modal>
+      <app-text
+        ex-large
+      >
+        本当に削除しますか?
+      </app-text>
+      <app-button
+        bg-danger
+        @click="$emit('handleClick')"
+      >
+        削除
+      </app-button>
+    </app-modal>
+  </div>
+</template>
+
+<script>
+import {
+  Heading,
+  ListItem,
+  RouterLink,
+  Button,
+  Text,
+} from '@Components/atoms';
+
+export default {
+  components: {
+    appHeading: Heading,
+    appListItem: ListItem,
+    appRouterLink: RouterLink,
+    appButton: Button,
+    appText: Text,
+  },
+  props: {
+    className: {
+      type: String,
+      default: '',
+    },
+    targetArray: {
+      type: Array,
+      default: () => [],
+    },
+    borderGray: {
+      type: Boolean,
+      default: false,
+    },
+    title: {
+      type: String,
+      default: 'すべて',
+    },
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    access: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    articleTitle() {
+      return `${this.title}の一覧`;
+    },
+    buttonText() {
+      return this.access.delete ? '削除' : '削除権限がありません';
+    },
+  },
+  methods: {
+    openModal(articleId) {
+      if (!this.access.delete) return;
+      this.$emit('openModal', articleId);
+    },
+  },
+};
+</script>
+
+<style lang="postcss" scoped>
+  .article-list {
+    &__articles {
+      margin-top: 16px;
+      .fade-enter-active, .fade-leave-active {
+        transition: opacity .5s;
+      }
+    }
+    .fade-enter, .fade-leave-to {
+      opacity: 0;
+    }
+    &__title {
+      width: 60%;
+    }
+    &__create-link {
+      margin-top: 16px;
+    }
+    &__links {
+      *:not(first-child) {
+        margin-left: 16px;
+      }
+    }
+    &__notice--create {
+      margin-bottom: 16px;
+    }
+  }
+</style>

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -11,14 +11,14 @@
         large
         border-bottom-gray
       >
+        <app-text class="article-list__created">
+          {{ article.created_at | dateLocalization }}
+        </app-text>
         <app-heading :level="3" class="article-list__title">
           {{
             article.title | wordLimitation
           }}
         </app-heading>
-        <app-text class="article-list__created">
-          {{ article.created_at | dateLocalization }}
-        </app-text>
         <app-text class="article-list__content">
           {{ article.content | wordLimitation }}
         </app-text>
@@ -109,6 +109,14 @@ export default {
   }
   &__title {
     width: 60%;
+    font-size: 20px;
+  }
+  &__created {
+    color: var(--disabledColor);
+    font-size: 14px;
+  }
+  &__content {
+    margin-top: 15px;
   }
 }
 </style>

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -1,11 +1,7 @@
 <template lang="html">
   <div class="article-list">
     <app-heading :level="1">{{ articleTitle }}</app-heading>
-    <transition-group
-      class="article-list__articles"
-      name="fade"
-      tag="ul"
-    >
+    <transition-group class="article-list__articles" name="fade" tag="ul">
       <app-list-item
         v-for="article in targetArray"
         :key="article.id"
@@ -16,10 +12,16 @@
         large
         border-bottom-gray
       >
-        <app-text
-          class="article-list__title"
-        >
-          {{ article.title }}
+        <app-heading :level="3" class="article-list__title">
+          {{
+            article.title
+          }}
+        </app-heading>
+        <app-text class="article-list__created">
+          作成日：{{ article.created_at | localization }}
+        </app-text>
+        <app-text class="article-list__content">
+          {{ article.content }}
         </app-text>
       </app-list-item>
     </transition-group>
@@ -27,17 +29,20 @@
 </template>
 
 <script>
-import {
-  Heading,
-  ListItem,
-  Text,
-} from '@Components/atoms';
+import { Heading, ListItem, Text } from '@Components/atoms';
 
 export default {
   components: {
     appHeading: Heading,
     appListItem: ListItem,
     appText: Text,
+  },
+  filters: {
+    localization(date) {
+      const ts = Date.parse(date);
+      const dt = new Date(ts);
+      return dt.toLocaleDateString();
+    },
   },
   props: {
     className: {
@@ -83,18 +88,20 @@ export default {
 </script>
 
 <style lang="postcss" scoped>
-  .article-list {
-    &__articles {
-      margin-top: 16px;
-      .fade-enter-active, .fade-leave-active {
-        transition: opacity .5s;
-      }
-    }
-    .fade-enter, .fade-leave-to {
-      opacity: 0;
-    }
-    &__title {
-      width: 60%;
+.article-list {
+  &__articles {
+    margin-top: 16px;
+    .fade-enter-active,
+    .fade-leave-active {
+      transition: opacity 0.5s;
     }
   }
+  .fade-enter,
+  .fade-leave-to {
+    opacity: 0;
+  }
+  &__title {
+    width: 60%;
+  }
+}
 </style>

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -6,22 +6,21 @@
         v-for="article in targetArray"
         :key="article.id"
         flex
-        beetween
-        align-items
+        direction-column
         bg-white
         large
         border-bottom-gray
       >
         <app-heading :level="3" class="article-list__title">
           {{
-            article.title
+            article.title | wordLimitation
           }}
         </app-heading>
         <app-text class="article-list__created">
-          作成日：{{ article.created_at | localization }}
+          {{ article.created_at | dateLocalization }}
         </app-text>
         <app-text class="article-list__content">
-          {{ article.content }}
+          {{ article.content | wordLimitation }}
         </app-text>
       </app-list-item>
     </transition-group>
@@ -38,10 +37,18 @@ export default {
     appText: Text,
   },
   filters: {
-    localization(date) {
+    dateLocalization(date) {
       const ts = Date.parse(date);
       const dt = new Date(ts);
       return dt.toLocaleDateString();
+    },
+    wordLimitation(word) {
+      const count = word.split('').length;
+      if (count > 30) {
+        const displayRange = word.slice(0, 31);
+        return `${displayRange}...`;
+      }
+      return word;
     },
   },
   props: {

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -11,7 +11,7 @@
         large
         border-bottom-gray
       >
-        <app-text class="article-list__created">
+        <app-text is="span" class="article-list__created">
           {{ article.created_at | dateLocalization }}
         </app-text>
         <app-heading :level="3" class="article-list__title">
@@ -44,11 +44,8 @@ export default {
     },
     wordLimitation(word) {
       const count = word.split('').length;
-      if (count > 30) {
-        const displayRange = word.slice(0, 31);
-        return `${displayRange}...`;
-      }
-      return word;
+      const displayRange = word.slice(0, 31);
+      return count > 30 ? `${displayRange}...` : word;
     },
   },
   props: {
@@ -68,27 +65,10 @@ export default {
       type: String,
       default: 'すべて',
     },
-    doneMessage: {
-      type: String,
-      default: '',
-    },
-    access: {
-      type: Object,
-      default: () => ({}),
-    },
   },
   computed: {
     articleTitle() {
       return `${this.title}の一覧`;
-    },
-    buttonText() {
-      return this.access.delete ? '削除' : '削除権限がありません';
-    },
-  },
-  methods: {
-    openModal(articleId) {
-      if (!this.access.delete) return;
-      this.$emit('openModal', articleId);
     },
   },
 };

--- a/src/js/components/molecules/ArticleTrashedList/index.vue
+++ b/src/js/components/molecules/ArticleTrashedList/index.vue
@@ -1,21 +1,6 @@
 <template lang="html">
   <div class="article-list">
-    <div v-if="doneMessage" class="article-list__notice--create">
-      <app-text bg-success>{{ doneMessage }}</app-text>
-    </div>
     <app-heading :level="1">{{ articleTitle }}</app-heading>
-    <app-router-link
-      to="articles/post"
-      key-color
-      white
-      bg-lightgreen
-      small
-      round
-      hover-opacity
-      class="article-list__create-link"
-    >
-      新しいドキュメントを作る
-    </app-router-link>
     <transition-group
       class="article-list__articles"
       name="fade"
@@ -36,51 +21,8 @@
         >
           {{ article.title }}
         </app-text>
-        <div class="article-list__links">
-          <app-router-link
-            :to="`/articles/${article.id}`"
-            theme-color
-            underline
-            hover-opacity
-          >
-            詳細
-          </app-router-link>
-          <app-router-link
-            :to="`/articles/${article.id}/edit`"
-            white
-            bg-lightgreen
-            small
-            round
-            hover-opacity
-          >
-            更新
-          </app-router-link>
-          <app-button
-            bg-danger
-            small
-            round
-            hover-opacity
-            :disabled="!access.delete"
-            @click="openModal(article.id)"
-          >
-            {{ buttonText }}
-          </app-button>
-        </div>
       </app-list-item>
     </transition-group>
-    <app-modal>
-      <app-text
-        ex-large
-      >
-        本当に削除しますか?
-      </app-text>
-      <app-button
-        bg-danger
-        @click="$emit('handleClick')"
-      >
-        削除
-      </app-button>
-    </app-modal>
   </div>
 </template>
 
@@ -88,8 +30,6 @@
 import {
   Heading,
   ListItem,
-  RouterLink,
-  Button,
   Text,
 } from '@Components/atoms';
 
@@ -97,8 +37,6 @@ export default {
   components: {
     appHeading: Heading,
     appListItem: ListItem,
-    appRouterLink: RouterLink,
-    appButton: Button,
     appText: Text,
   },
   props: {
@@ -157,17 +95,6 @@ export default {
     }
     &__title {
       width: 60%;
-    }
-    &__create-link {
-      margin-top: 16px;
-    }
-    &__links {
-      *:not(first-child) {
-        margin-left: 16px;
-      }
-    }
-    &__notice--create {
-      margin-bottom: 16px;
     }
   }
 </style>

--- a/src/js/components/molecules/index.js
+++ b/src/js/components/molecules/index.js
@@ -5,6 +5,7 @@ import SidebarList from './SidebarList';
 import HomeCategory from './HomeCategory';
 import HomeArticle from './HomeArticle';
 import ArticleList from './ArticleList';
+import ArticleTrashedList from './ArticleTrashedList';
 import UserCreate from './UserCreate';
 import UserTable from './UserTable';
 import UserDetail from './UserDetail';
@@ -26,6 +27,7 @@ export {
   HomeCategory,
   HomeArticle,
   ArticleList,
+  ArticleTrashedList,
   UserCreate,
   UserTable,
   UserDetail,

--- a/src/js/pages/Articles/TrashedList.vue
+++ b/src/js/pages/Articles/TrashedList.vue
@@ -22,18 +22,17 @@ export default {
   },
   computed: {
     articlesList() {
-      return this.$store.state.articles.articleList;
+      return this.$store.state.articles.trashedArticleList;
     },
   },
   created() {
-    const categoryName = this.$route.query.category ? this.$route.query.category : null;
-    this.fetchArticles(categoryName);
+    this.fetchArticles();
   },
   methods: {
-    fetchArticles(categoryName) {
-      this.$store.dispatch('articles/getArticles', categoryName)
+    fetchArticles() {
+      this.$store.dispatch('articles/getTrashedArticles')
         .then(() => {
-          if (this.$store.state.articles.articleList.length === 0) {
+          if (this.$store.state.articles.trashedArticleList.length === 0) {
             this.$router.push({ path: '/notfound' });
           }
         }).catch(() => {

--- a/src/js/pages/Articles/TrashedList.vue
+++ b/src/js/pages/Articles/TrashedList.vue
@@ -1,0 +1,75 @@
+<template lang="html">
+  <div class="articles">
+    <app-article-trashed-list
+      :title="title"
+      :target-array="articlesList"
+      :done-message="doneMessage"
+      :access="access"
+      border-gray
+      @openModal="openModal"
+      @handleClick="handleClick"
+    />
+  </div>
+</template>
+
+<script>
+import { ArticleTrashedList } from '@Components/molecules';
+import Mixins from '@Helpers/mixins';
+
+export default {
+  components: {
+    appArticleTrashedList: ArticleTrashedList,
+  },
+  mixins: [Mixins],
+  beforeRouteUpdate(to, from, next) {
+    const categoryName = to.query.category ? to.query.category : null;
+    this.fetchArticles(categoryName);
+    next();
+  },
+  data() {
+    return {
+      title: 'すべて',
+    };
+  },
+  computed: {
+    articlesList() {
+      return this.$store.state.articles.articleList;
+    },
+    doneMessage() {
+      return this.$store.state.articles.doneMessage;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+  },
+  created() {
+    const categoryName = this.$route.query.category ? this.$route.query.category : null;
+    this.fetchArticles(categoryName);
+  },
+  methods: {
+    openModal(articleId) {
+      this.$store.dispatch('articles/confirmDeleteArticle', articleId);
+      this.toggleModal();
+    },
+    handleClick() {
+      this.$store.dispatch('articles/deleteArticle')
+        .then(() => {
+          this.toggleModal();
+          const categoryName = this.$route.query.category
+            ? this.$route.query.category : null;
+          this.$store.dispatch('articles/getArticles', categoryName);
+        });
+    },
+    fetchArticles(categoryName) {
+      this.$store.dispatch('articles/getArticles', categoryName)
+        .then(() => {
+          if (this.$store.state.articles.articleList.length === 0) {
+            this.$router.push({ path: '/notfound' });
+          }
+        }).catch(() => {
+          // console.log(err);
+        });
+    },
+  },
+};
+</script>

--- a/src/js/pages/Articles/TrashedList.vue
+++ b/src/js/pages/Articles/TrashedList.vue
@@ -22,11 +22,11 @@ export default {
   },
   computed: {
     articlesList() {
-      return this.$store.state.articles.trashedArticleList;
+      return this.$store.getters['articles/sortDateTrashedArticles'];
     },
   },
-  created() {
-    this.fetchArticles();
+  async created() {
+    await this.fetchArticles();
   },
   methods: {
     fetchArticles() {

--- a/src/js/pages/Articles/TrashedList.vue
+++ b/src/js/pages/Articles/TrashedList.vue
@@ -3,43 +3,26 @@
     <app-article-trashed-list
       :title="title"
       :target-array="articlesList"
-      :done-message="doneMessage"
-      :access="access"
       border-gray
-      @openModal="openModal"
-      @handleClick="handleClick"
     />
   </div>
 </template>
 
 <script>
 import { ArticleTrashedList } from '@Components/molecules';
-import Mixins from '@Helpers/mixins';
 
 export default {
   components: {
     appArticleTrashedList: ArticleTrashedList,
   },
-  mixins: [Mixins],
-  beforeRouteUpdate(to, from, next) {
-    const categoryName = to.query.category ? to.query.category : null;
-    this.fetchArticles(categoryName);
-    next();
-  },
   data() {
     return {
-      title: 'すべて',
+      title: '削除済み',
     };
   },
   computed: {
     articlesList() {
       return this.$store.state.articles.articleList;
-    },
-    doneMessage() {
-      return this.$store.state.articles.doneMessage;
-    },
-    access() {
-      return this.$store.getters['auth/access'];
     },
   },
   created() {
@@ -47,19 +30,6 @@ export default {
     this.fetchArticles(categoryName);
   },
   methods: {
-    openModal(articleId) {
-      this.$store.dispatch('articles/confirmDeleteArticle', articleId);
-      this.toggleModal();
-    },
-    handleClick() {
-      this.$store.dispatch('articles/deleteArticle')
-        .then(() => {
-          this.toggleModal();
-          const categoryName = this.$route.query.category
-            ? this.$route.query.category : null;
-          this.$store.dispatch('articles/getArticles', categoryName);
-        });
-    },
     fetchArticles(categoryName) {
       this.$store.dispatch('articles/getArticles', categoryName)
         .then(() => {

--- a/src/js/pages/Articles/TrashedList.vue
+++ b/src/js/pages/Articles/TrashedList.vue
@@ -35,8 +35,6 @@ export default {
           if (this.$store.state.articles.trashedArticleList.length === 0) {
             this.$router.push({ path: '/notfound' });
           }
-        }).catch(() => {
-          // console.log(err);
         });
     },
   },


### PR DESCRIPTION
## 変更内容

* 削除済みの記事を一覧にして表示
* 専用のページを作成
* 専用のリンクをナビゲーションメニューに追加

## 確認方法

- [x]  サイドのナビゲーションバーから『削除済み記事』を選択
- [x] 専用ページへ飛ぶ
- [x] 見つからなければ404ページへ飛ぶ
- [x] 専用ページにて一覧が表示される
- [x] 表示コンテンツは、「作成日」、「タイトル」、「内容」
- [x] タイトルと内容は31文字以降は「...」と表示される