### PR TITLE
【課題1】カテゴリー新規作成の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -84,6 +84,26 @@ export default {
         commit('toggleLoading');
       });
     },
+    // categoryの追加
+    addCategory({ commit, rootGetters }, categoryName) {
+      return new Promise( resolve => {
+        commit('toggleLoading');
+        const data = new URLSearchParams();
+        data.append('name', categoryName);
+        axios(rootGetters['auth/token'])({
+          method: 'POST',
+          url: '/category',
+          data,
+        }).then( response => {
+          commit('addCategory');
+          commit('toggleLoading');
+          resolve();
+        }).catch( err => {
+          commit('failFetchCategory', { message: err.message });
+          commit('toggleLoading');
+        });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -119,6 +139,10 @@ export default {
       state.updateCategoryId = payload.id;
       state.updateCategoryId = payload.name;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    // categoryの追加時のメッセージ
+    addCategory(state) {
+      state.doneMessage = 'カテゴリーの追加が完了しました';
     },
   },
 };

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -1,6 +1,7 @@
 <template lang="html">
   <div class="category-management">
     <section class="category-management-post">
+      <!-- formのaddCategoryのemitによってhandleSubmitを追加 -->
       <app-category-post
         :category="category"
         :disabled="loading ? true : false"
@@ -9,6 +10,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
+        @handleSubmit="handleSubmit"
       />
     </section>
     <section class="category-management-list">
@@ -86,6 +88,13 @@ export default {
           this.$store.dispatch('categories/getAllCategories');
         });
       this.toggleModal();
+    },
+    handleSubmit() {
+      this.$store.dispatch('categories/addCategory', this.category)
+        .then(() => {
+          this.category = '';
+          this.$store.dispatch('categories/getAllCategories');
+        });
     },
   },
 };


### PR DESCRIPTION
■チケットのリンク
https://gizumo.backlog.com/view/GIZFE-335
https://gizumo.backlog.com/view/GIZFE-336

■作業内容
カテゴリー新規作成の実装
(formの送信ボタンをクリックし、カテゴリーを追加する際の処理を作成)

■確認事項

![Kapture 2021-11-30 at 15 18 43](https://user-images.githubusercontent.com/84653168/143996387-5c03481c-95a9-4a0f-80b6-e0391f1c76c5.gif)

![category_api](https://user-images.githubusercontent.com/84653168/143996920-cfa9e2d1-616a-4bdc-8c10-f05f5e90bc51.png)

- [x] Atomic Designの概要を口頭で確認するので説明してください(前回のレビュー時確認済み)
- [x] urlは/categories/
- [x] インプットタグ内に入力されている値をカテゴリー登録apiを使用して登録されていること
- [x] 「作成」ボタンを押した時はAPI通信が完了するまでボタンを非活性になっていること
- [x] カテゴリーの作成に成功したときは、「カテゴリーの追加が完了しました」というメッセージが表示されていること
- [x] カテゴリーの作成に成功したあと、画面右側に表示されているカテゴリー一覧の表示が更新されていること