### PR TITLE
【課題2】カテゴリー更新機能の実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -72,6 +72,19 @@ export default {
         });
       });
     },
+    // 初期状態でカテゴリー名を取得
+    getCategoryDetail({ commit, rootGetters }, { id }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: `/category/${id}`,
+      }).then( response => {
+        // id,name情報が入っているobjectをpayloadに代入
+        const payload = response.data.category;
+        commit('getCategoryDetail', payload);
+      }).catch( err => {
+        commit('failFetchCategory', { message: err.message });
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -100,5 +113,9 @@ export default {
     addCategory(state) {
       state.doneMessage = 'カテゴリーの追加が完了しました';
     },
+    // 初期状態でカテゴリー名の取得
+    getCategoryDetail(state , payload) {
+      state.updateCategoryName = payload.name;
+    }
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -85,6 +85,10 @@ export default {
         commit('failFetchCategory', { message: err.message });
       });
     },
+    // valueの書き換え
+    changeCategoryName({ commit }, categoryName) {
+      commit('changeCategoryName', categoryName);
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -116,6 +120,10 @@ export default {
     // 初期状態でカテゴリー名の取得
     getCategoryDetail(state , payload) {
       state.updateCategoryName = payload.name;
-    }
+    },
+    // valueの書き換え
+    changeCategoryName(state, categoryName) {
+      state.updateCategoryName = categoryName;
+    },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -89,6 +89,25 @@ export default {
     changeCategoryName({ commit }, categoryName) {
       commit('changeCategoryName', categoryName);
     },
+    // 変更したvalueの保存
+    updateCategory({ commit, rootGetters }) {
+      commit('toggleLoading');
+      const data = new URLSearchParams();
+      data.append('name', this.state.categories.updateCategoryName);
+      data.append('id', this.state.categories.updateCategoryId);
+      axios(rootGetters['auth/token'])({
+        method: 'PUT',
+        url: `/category/${this.state.categories.updateCategoryId}`,
+        data,
+      }).then( response => {
+        const payload = response.data.category;
+        commit('updateCategory', payload);
+        commit('toggleLoading');
+      }).catch( err => {
+        commit('failFetchCategory', { message: err.message });
+        commit('toggleLoading');
+      });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -118,12 +137,19 @@ export default {
       state.doneMessage = 'カテゴリーの追加が完了しました';
     },
     // 初期状態でカテゴリー名の取得
-    getCategoryDetail(state , payload) {
+    getCategoryDetail(state, payload) {
       state.updateCategoryName = payload.name;
+      state.updateCategoryId = payload.id;
     },
     // valueの書き換え
     changeCategoryName(state, categoryName) {
       state.updateCategoryName = categoryName;
+    },
+    // 変更したvalueの保存
+    updateCategory(state, payload) {
+      state.updateCategoryName = payload.name;
+      state.updateCategoryId = payload.id;
+      state.doneMessage = 'カテゴリーの更新が完了しました。';
     },
   },
 };

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -11,13 +11,19 @@
     >
       カテゴリー一覧へ戻る
     </app-router-link>
+    <!-- v-validateはシングルクォートで囲んで文字列であると伝える必要がある -->
+    <!-- data-vv-asで項目名を日本語で表示させる -->
+    <!-- errorMessagesと紐付け -->
+    <!-- 多分fieldNameはname属性と同じで動作するはず -->
     <app-input
       class="category-management-edit__input"
       name="updateCategory"
       type="text"
       placeholder="カテゴリー名を入力してください"
-      data-vv-as=""
+      data-vv-as="カテゴリー名"
       :value="updateCategoryName"
+      v-validate="'required'"
+      :error-messages="errors.collect('updateCategory')"
     />
     <app-button
       class="category-management-edit__submit"

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -27,12 +27,14 @@
       {{ buttonText }}
     </app-button>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-error>ここにエラー時のメッセージが入ります</app-text>
+    <!-- v-ifで分岐させないと表示が残る -->
+    <div v-if="errorMessage" class="category-management-edit__notice">
+      <app-text bg-error>{{ errorMessage }}</app-text>
     </div>
 
-    <div class="category-management-edit__notice">
-      <app-text bg-success>ここに更新成功時のメッセージが入ります</app-text>
+    <!-- v-ifで分岐 -->
+    <div v-if="doneMessage" class="category-management-edit__notice">
+      <app-text bg-success>{{ doneMessage }}</app-text>
     </div>
   </form>
 </template>
@@ -57,6 +59,15 @@ export default {
     access: {
       type: Object,
       default: () => ({}),
+    },
+    // 成功時,エラー時のメッセージの受け取り
+    doneMessage: {
+      type: String,
+      default: '',
+    },
+    errorMessage: {
+      type: String,
+      default: '',      
     },
   },
   computed: {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -15,6 +15,7 @@
     <!-- data-vv-asで項目名を日本語で表示させる -->
     <!-- errorMessagesと紐付け -->
     <!-- 多分fieldNameはname属性と同じで動作するはず -->
+    <!-- inputコンポーネントで使用しているupdateValueという値を使い回す -->
     <app-input
       class="category-management-edit__input"
       name="updateCategory"
@@ -24,6 +25,7 @@
       :value="updateCategoryName"
       v-validate="'required'"
       :error-messages="errors.collect('updateCategory')"
+      @updateValue="$emit('updateValue', $event)"
     />
     <app-button
       class="category-management-edit__submit"
@@ -76,6 +78,7 @@ export default {
       type: String,
       default: '',      
     },
+    // 初期段階のカテゴリー名を表示する値の受け取り
     updateCategoryName: {
       type: String,
       default: '',

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -17,6 +17,7 @@
       type="text"
       placeholder="カテゴリー名を入力してください"
       data-vv-as=""
+      :value="updateCategoryName"
     />
     <app-button
       class="category-management-edit__submit"
@@ -68,6 +69,10 @@ export default {
     errorMessage: {
       type: String,
       default: '',      
+    },
+    updateCategoryName: {
+      type: String,
+      default: '',
     },
   },
   computed: {

--- a/src/js/components/molecules/CategoryEdit/index.vue
+++ b/src/js/components/molecules/CategoryEdit/index.vue
@@ -76,7 +76,7 @@ export default {
     },
     errorMessage: {
       type: String,
-      default: '',      
+      default: '',
     },
     // 初期段階のカテゴリー名を表示する値の受け取り
     updateCategoryName: {
@@ -95,7 +95,8 @@ export default {
       if (!this.access.edit) return;
       this.$emit('clearMessage');
       this.$validator.validate().then((valid) => {
-        if (valid) this.$emit('エミットするイベント名が入ります');
+        // ボタンを押した際にバリデートが走る
+        if (valid) this.$emit('handleSubmit');
       });
     },
   },

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -6,6 +6,7 @@
       @clearMessage="clearMessage"
       :done-message="doneMessage"
       :error-message="errorMessage"
+      :update-category-name="updateCategoryName"
     />
   </div>
 </template>
@@ -30,7 +31,17 @@ export default {
     },
     errorMessage() {
       return this.$store.state.categories.errorMessage;
+    },
+    updateCategoryName() {
+      return this.$store.state.categories.updateCategoryName;
     }
+  },
+  // 更新対象の情報の取得
+  // created段階で実行
+  created() {
+    const { id } = this.$route.params;
+    this.$store.dispatch('categories/getCategoryDetail', { id });
+    this.$store.dispatch('categories/clearMessage');
   },
   methods: {
     clearMessage() {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -4,6 +4,8 @@
       :disabled="loading ? true : false"
       :access="access"
       @clearMessage="clearMessage"
+      :done-message="doneMessage"
+      :error-message="errorMessage"
     />
   </div>
 </template>
@@ -22,6 +24,13 @@ export default {
     loading() {
       return this.$store.state.categories.loading;
     },
+    // 成功時、エラー時のメッセージ
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    }
   },
   methods: {
     clearMessage() {

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -8,6 +8,7 @@
       :error-message="errorMessage"
       :update-category-name="updateCategoryName"
       @updateValue="updateValue"
+      @handleSubmit="handleSubmit"
     />
   </div>
 </template>
@@ -36,7 +37,7 @@ export default {
     // 元々のカテゴリー名
     updateCategoryName() {
       return this.$store.state.categories.updateCategoryName;
-    }
+    },
   },
   // 更新対象の情報の取得
   // created段階で実行
@@ -51,7 +52,11 @@ export default {
     },
     // valueの書き換え
     updateValue($event) {
-      this.$store.dispatch('categories/changeCategoryName', $event.target.value)
+      this.$store.dispatch('categories/changeCategoryName', $event.target.value);
+    },
+    // 送信ボタンを押した時に変更したvalueを保存する
+    handleSubmit() {
+      this.$store.dispatch('categories/updateCategory');
     },
   },
 };

--- a/src/js/pages/Categories/Edit.vue
+++ b/src/js/pages/Categories/Edit.vue
@@ -7,6 +7,7 @@
       :done-message="doneMessage"
       :error-message="errorMessage"
       :update-category-name="updateCategoryName"
+      @updateValue="updateValue"
     />
   </div>
 </template>
@@ -32,6 +33,7 @@ export default {
     errorMessage() {
       return this.$store.state.categories.errorMessage;
     },
+    // 元々のカテゴリー名
     updateCategoryName() {
       return this.$store.state.categories.updateCategoryName;
     }
@@ -46,6 +48,10 @@ export default {
   methods: {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
+    },
+    // valueの書き換え
+    updateValue($event) {
+      this.$store.dispatch('categories/changeCategoryName', $event.target.value)
     },
   },
 };


### PR DESCRIPTION
## チケットのリンク
【レビュー用】
https://gizumo.backlog.com/view/GIZFE-338
【コーディング用】
https://gizumo.backlog.com/view/GIZFE-337

## 作業内容

**◎カテゴリー更新機能の実装**

【実装内容詳細】
- API通信時の更新成功・失敗したときのメッセージ表示を実装
- 初期状態でinputタグに更新対象のテキストを表示する処理を実装
- vee-validateを使用してテキスト入力必須&バリデーションエラーの表示処理の実装
- inputタグに入力した内容に基づいてvalueの値が変更する処理を実装
- 変更したvalueの値を保存する処理を実装

## 挙動の確認

![wiki2](https://user-images.githubusercontent.com/84653168/144536513-502efcd6-a775-42c7-ba30-90f06514c54e.gif)

## 確認事項

- [x] urlは/categories/{id}と表示されていること
- [x] ページにアクセスしたときの初期表示として、inputタグに更新対象のテキストを表示されていること
- [x] inputタグにはテキスト入力必須のバリデーションが適用されていること
- [x] 3のバリデーションエラーが発生した場合は適切なフィールド名の入力エラー文言(カテゴリー名は入力必須です)を表示されていること
- [x] api通信を行い更新に成功した時は、ハードコードされている「ここに更新成功時のメッセージが入ります」メッセージを適切な文言として表示されていること
- [x] api通信を行い更新に失敗した時は、ハードコードされている「ここにエラー時のメッセージが入ります」メッセージを適切な文言として表示されていること
- [x] json web tokenについて口頭で説明してください