### PR TITLE
【課題3】カテゴリー一覧の機能実装

### DIFF
--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -103,6 +103,10 @@ export default {
         commit('toggleLoading');
       });
     },
+    // 削除対象ののカテゴリーを取得
+    getDeleteCategory({ commit }, { deleteCategoryName , deleteCategoryId }) {
+      commit('getDeleteCategory' , { deleteCategoryName , deleteCategoryId });
+    },
   },
   mutations: {
     clearMessage(state) {
@@ -141,6 +145,10 @@ export default {
       state.updateCategoryName = payload.name;
       state.updateCategoryId = payload.id;
       state.doneMessage = 'カテゴリーの更新が完了しました。';
+    },
+    getDeleteCategory(state, { deleteCategoryName , deleteCategoryId }) {
+      state.deleteCategoryName = deleteCategoryName;
+      state.deleteCategoryId = deleteCategoryId;
     },
   },
 };

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -19,9 +19,17 @@ export default {
     clearMessage({ commit }) {
       commit('clearMessage');
     },
-    getAllCategories({ commit }) {
-      const payload = { categories: [{ id: 9999, name: 'ダミーカテゴリー' }] };
-      commit('doneGetAllCategories', payload);
+    // カテゴリー欄を取得
+    getAllCategories({ commit,rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then( response => {
+        const payload = response.data;
+        commit('doneGetAllCategories',payload);
+      }).catch( err => {
+        commit('failFetchCategory', { message: err.message });
+      });
     },
     deleteCategory({ commit, rootGetters }, categoryId) {
       return new Promise((resolve) => {

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -46,7 +46,7 @@
               small
               round
               :disabled="!access.delete"
-              @click="openModal()"
+              @click="openModal(category.name, category.id)"
             >
               削除
             </app-button>
@@ -68,7 +68,7 @@
           theme-color
           tag="p"
         >
-          ここに削除するカテゴリー名が入ります
+          {{ deleteCategoryName }}
         </app-text>
         <app-button
           class="category-list__modal__button"
@@ -111,15 +111,22 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    // 削除対象のカテゴリー名
+    deleteCategoryName: {
+      type: String,
+      default: '',
+    },
   },
   methods: {
-    openModal() {
+    // モーダルの実行
+    openModal(deleteCategoryName , deleteCategoryId) {
       if (!this.access.delete) return;
-      this.$emit('openModal');
+      this.$emit('openModal', deleteCategoryName, deleteCategoryId);
     },
+    // 指定したカテゴリーの削除
     handleClick() {
       if (!this.access.delete) return;
-      this.$emit('ここにエミットするイベント名が入ります');
+      this.$emit('handleClick');
     },
   },
 };

--- a/src/js/components/molecules/CategoryList/index.vue
+++ b/src/js/components/molecules/CategoryList/index.vue
@@ -25,6 +25,7 @@
               underline
               small
               hover-opacity
+              :to="`/articles?category=${category.name}`"
             >
               このカテゴリーの記事
             </app-router-link>
@@ -34,6 +35,7 @@
               theme-color
               underline
               hover-opacity
+              :to="`/categories/${category.id}`"
             >
               更新
             </app-router-link>

--- a/src/js/pages/Categories/Management.vue
+++ b/src/js/pages/Categories/Management.vue
@@ -2,6 +2,7 @@
   <div class="category-management">
     <section class="category-management-post">
       <!-- formのaddCategoryのemitによってhandleSubmitを追加 -->
+      <!-- handleSubmitからaddCategoryに変更 -->
       <app-category-post
         :category="category"
         :disabled="loading ? true : false"
@@ -10,7 +11,7 @@
         :access="access"
         @udpateValue="updateValue"
         @clearMessage="clearMessage"
-        @handleSubmit="handleSubmit"
+        @handleSubmit="addCategory"
       />
     </section>
     <section class="category-management-list">
@@ -20,6 +21,7 @@
         :delete-category-name="deleteCategoryName"
         :access="access"
         @openModal="openModal"
+        @handleClick="deleteCategory"
       />
     </section>
   </div>
@@ -75,17 +77,25 @@ export default {
     clearMessage() {
       this.$store.dispatch('categories/clearMessage');
     },
-    openModal() {
+    openModal(deleteCategoryName , deleteCategoryId) {
       this.toggleModal();
       this.$store.dispatch('categories/clearMessage');
+      this.$store.dispatch('categories/getDeleteCategory', { deleteCategoryName , deleteCategoryId });
     },
-    handleSubmit() {
+    addCategory() {
       this.$store.dispatch('categories/addCategory', this.category)
-        .then(() => {
-          this.category = '';
-          this.$store.dispatch('categories/getAllCategories');
-        });
+      .then(() => {
+        this.category = '';
+        this.$store.dispatch('categories/getAllCategories');
+      });
     },
+    deleteCategory() {
+      this.$store.dispatch('categories/deleteCategory',this.deleteCategoryId)
+      .then(() => {
+        this.$store.dispatch('categories/getAllCategories');
+      });
+      this.toggleModal();
+    }
   },
 };
 </script>


### PR DESCRIPTION
## チケットのリンク
【レビュー用】
https://gizumo.backlog.com/view/GIZFE-340
【コーディング用】
https://gizumo.backlog.com/view/GIZFE-339

## 作業内容

**◎カテゴリー一覧の機能実装**
- 取得したカテゴリーを一覧表示
- 「このカテゴリーの記事」「更新」の対象のリンクに遷移する処理
- ドロワーの実装、カテゴリーの削除機能実装

## 挙動の確認

![wiki2](https://user-images.githubusercontent.com/84653168/145343542-ceccae5b-cf75-4e86-8a73-435694d370ba.gif)

## 確認事項

- [x] urlは/categories
- [x] ページにアクセスしたときの初期表示として、カテゴリー一覧APIから取得したデータを基にカテゴリーの一覧が表示されていること
- [x] 「カテゴリー名」のテーブルに取得したカテゴリーの一覧を表示されていること
- [x] 「このカテゴリーの記事」のリンクをクリックすると、該当のカテゴリーに属している記事一覧が表示されていること
- [x] 「更新」ボタンをクリックすると、そのカテゴリーの詳細・編集画面に遷移されること
- [x] 「削除」 ボタンをクリックして表示されるモーダル内に、削除対象のカテゴリー名が表示されていること
- [x] モーダルの「削除する」ボタンをクリックしたら、6で表示されているカテゴリーが削除され、その後にモーダルが閉じ削除された状態のカテゴリー一覧が表示されていること